### PR TITLE
enhancement(compat): Ensure backwards compatibility to 1.11, adds compat helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
 
 env:
   # we recommend testing LTS's and latest stable release (bonus points to beta/canary)
+  - EMBER_TRY_SCENARIO=ember-1.11
+  - EMBER_TRY_SCENARIO=ember-1.13
   - EMBER_TRY_SCENARIO=ember-lts-2.4
   - EMBER_TRY_SCENARIO=ember-lts-2.8
   - EMBER_TRY_SCENARIO=ember-release

--- a/addon/object/computed.js
+++ b/addon/object/computed.js
@@ -5,6 +5,10 @@ import {
   decoratedPropertyWithOptionalCallback
 } from '../utils/decorator-macros';
 
+import {
+  SUPPORTS_UNIQ_BY_COMPUTED
+} from 'ember-compatibility-helpers';
+
 /**
  * Decorator that wraps [Ember.computed.alias](http://emberjs.com/api/classes/Ember.computed.html#method_alias)
  *
@@ -811,7 +815,7 @@ export const uniq = decoratedPropertyWithRequiredParams(Ember.computed.uniq);
  * @param {String} dependentKey - Key of the array to uniq
  * @param {String} propertyKey - Key of the property on the objects of the array to determine uniqueness by
  */
-export const uniqBy = Ember.computed.uniqBy ?
+export const uniqBy = SUPPORTS_UNIQ_BY_COMPUTED ?
   decoratedPropertyWithRequiredParams(Ember.computed.uniqBy) :
   () => {
     assert('uniqBy is only available from Ember.js v2.7 onwards.', false);

--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,0 @@
-{
-  "name": "ember-decorators",
-  "dependencies": {}
-}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,6 +2,50 @@
 module.exports = {
   scenarios: [
     {
+      name: 'ember-1.11',
+      bower: {
+        dependencies: {
+          'ember': '~1.11.0',
+          'ember-cli-shims': '0.0.6',
+          'ember-data': '~1.13.0'
+        },
+        resolutions: {
+          'ember': '~1.11.0',
+          'ember-cli-shims': '0.0.6',
+          'ember-data': '~1.13.0'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-cli-shims': null,
+          'ember-data': '~1.13.0',
+          'ember-source': null
+        }
+      }
+    },
+    {
+      name: 'ember-1.13',
+      bower: {
+        dependencies: {
+          'ember': '~1.13.0',
+          'ember-cli-shims': '0.0.6',
+          'ember-data': '~1.13.0'
+        },
+        resolutions: {
+          'ember': '~1.13.0',
+          'ember-cli-shims': '0.0.6',
+          'ember-data': '~1.13.0'
+        }
+      },
+      npm: {
+        devDependencies: {
+          'ember-cli-shims': null,
+          'ember-data': '~1.13.0',
+          'ember-source': null
+        }
+      }
+    },
+    {
       name: 'ember-lts-2.4',
       bower: {
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "ember-cli-babel": "^6.0.0",
     "ember-cli-version-checker": "^2.0.0",
+    "ember-compatibility-helpers": "^0.1.0",
     "ember-macro-helpers": "^0.15.1"
   },
   "devDependencies": {

--- a/tests/unit/action-test.js
+++ b/tests/unit/action-test.js
@@ -6,6 +6,8 @@ import { moduleForComponent } from 'ember-qunit';
 import { test } from 'qunit';
 import { findAll, click } from 'ember-native-dom-helpers';
 
+import { HAS_UNDERSCORE_ACTIONS } from 'ember-compatibility-helpers';
+
 moduleForComponent('actions', { integration: true });
 
 test('action decorator works with standard Ember Object model', function(assert) {
@@ -68,14 +70,16 @@ test('action decorator does not add actions to superclass', function(assert) {
   }
 
   const foo = new Foo();
-
-  assert.equal(typeof foo.actions.foo, 'function', 'foo has foo action');
-  assert.equal(typeof foo.actions.bar, 'undefined', 'foo does not have bar action');
-
   const bar = new Bar();
 
-  assert.equal(typeof bar.actions.foo, 'function', 'bar has foo action');
-  assert.equal(typeof bar.actions.bar, 'function', 'bar has bar action');
+  const fooActions = HAS_UNDERSCORE_ACTIONS ? foo._actions : foo.actions;
+  const barActions = HAS_UNDERSCORE_ACTIONS ? bar._actions : bar.actions;
+
+  assert.equal(typeof fooActions.foo, 'function', 'foo has foo action');
+  assert.equal(typeof fooActions.bar, 'undefined', 'foo does not have bar action');
+
+  assert.equal(typeof barActions.foo, 'function', 'bar has foo action');
+  assert.equal(typeof barActions.bar, 'function', 'bar has bar action');
 });
 
 test('actions are properly merged through traditional and ES6 prototype hierarchy', async function(assert) {

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -4,11 +4,7 @@ import { module, test } from 'qunit';
 
 const { get, set, setProperties } = Ember;
 
-module('decorated computed with dependent keys', {
-  beforeEach() {
-
-  }
-});
+module('computed properties');
 
 test('passes dependent keys into function as arguments', function(assert) {
   var obj = {
@@ -82,48 +78,7 @@ test('only calls getter when dependent keys change', function(assert) {
   assert.equal(callCount, 1);
 });
 
-test('allows using ember-new-computed style get/set syntax', function(assert) {
-  // not currently supported by Babel (waiting on confirmation from @wycats
-  // before opening an issue)
-  let setCallCount = 0;
-  let getCallCount = 0;
-  let obj = {
-    first: 'rob',
-    last: 'jackson',
 
-    @computed('first', 'last')
-    name: {
-      get(first, last) {
-        assert.equal(first, 'rob');
-        assert.equal(last, 'jackson');
-
-        getCallCount++;
-      },
-
-      set(value, first, last) {
-        assert.equal(first, 'rob');
-        assert.equal(last, 'jackson');
-
-        setCallCount++;
-
-        return `${value}-transformed`;
-      }
-    }
-  };
-
-  get(obj, 'name');
-  assert.equal(getCallCount, 1, 'calls getter initially');
-
-  get(obj, 'name');
-  assert.equal(getCallCount, 1, 'does not call getter when cache is not busted');
-
-  set(obj, 'name', 'foo');
-  assert.equal(setCallCount, 1, 'calls setter when set');
-
-  assert.strictEqual(get(obj, 'name'), 'foo-transformed', 'return value of setter is new value of computed property')
-});
-
-module('decorated computed without dependent keys');
 
 test('works properly', function(assert) {
   let callCount = 0;
@@ -142,123 +97,6 @@ test('works properly', function(assert) {
   get(obj, 'name');
 
   assert.equal(callCount, 1);
-});
-
-test('attr.foo passes attr.foo', function(assert) {
-  assert.expect(2);
-
-  let obj = {
-    attr: {
-      foo: 'bar'
-    },
-
-    @computed('attr.foo')
-    something: {
-      get(foo) {
-        assert.deepEqual(foo, 'bar');
-      },
-      set(value, foo) {
-        assert.deepEqual(foo, 'bar');
-      }
-    },
-  };
-
-  get(obj, 'something');
-  set(obj, 'something', 'something');
-});
-
-test('attr.models.@each passes attr.models', function(assert) {
-  assert.expect(2);
-
-  let obj = {
-    attr: {
-      models: ['one', 'two']
-    },
-
-    @computed('attr.models.@each.length')
-    something: {
-      get(models) {
-        assert.deepEqual(models, ['one', 'two']);
-      },
-      set(value, models) {
-        assert.deepEqual(models, ['one', 'two']);
-      }
-    },
-  };
-
-  get(obj, 'something');
-  set(obj, 'something', 'something');
-});
-
-test('attr.models.[] passes attr.models', function(assert) {
-  assert.expect(2);
-
-  let obj = {
-    models: ['one', 'two'],
-
-    @computed('models.[]')
-    something: {
-      get(models) {
-        assert.deepEqual(models, ['one', 'two']);
-      },
-      set(value, models) {
-        assert.deepEqual(models, ['one', 'two']);
-      }
-    },
-  };
-
-  get(obj, 'something');
-  set(obj, 'something', 'something');
-});
-
-test('attr.{foo,bar} passes attr.foo and attr.bar', function(assert) {
-  assert.expect(4);
-
-  let obj = {
-    attr: {
-      foo: 'foo',
-      bar: 'bar'
-    },
-
-    @computed('attr.{foo,bar}')
-    something: {
-      get(foo, bar) {
-        assert.equal(foo, 'foo');
-        assert.equal(bar, 'bar');
-      },
-      set(value, foo, bar) {
-        assert.equal(foo, 'foo');
-        assert.equal(bar, 'bar');
-      }
-    },
-  };
-
-  get(obj, 'something');
-  set(obj, 'something', 'something');
-});
-
-test('attr.@each.{foo,bar} passes attr', function(assert) {
-  assert.expect(2);
-
-  let obj = {
-    attr: [{
-      foo: 'foo',
-      bar: 'bar'
-    }],
-
-    @computed('attr.@each.{foo,bar}')
-    something: {
-      get(models) {
-        assert.deepEqual(models, [{ foo: 'foo', bar: 'bar' }]);
-      },
-      set(value, models) {
-        assert.deepEqual(models, [{ foo: 'foo', bar: 'bar' }]);
-      }
-    },
-  };
-
-  get(obj, 'something');
-  set(obj, 'something', 'something');
 });
 
 test('works with es6 class', function(assert) {
@@ -380,7 +218,7 @@ test('return value of ES6 setter is not required, but is not ignored', function(
     set fullNameWithReturn(name) {
       const [first, last] = name.split(' ');
       setProperties(this, { first, last });
-      
+
       return 'something else';
     }
   }

--- a/tests/unit/macro-test.js
+++ b/tests/unit/macro-test.js
@@ -494,7 +494,7 @@ test('readOnly', function(assert) {
     () => {
       obj.set('finalName', 'Brotom');
     },
-    /Cannot set read-only property 'finalName' on object/,
+    /Cannot set read-only property ['"]finalName['"] on object/,
     'error message thrown when trying to set readOnly property'
   );
 

--- a/tests/unit/new-computed-test.js
+++ b/tests/unit/new-computed-test.js
@@ -1,0 +1,169 @@
+import Ember from 'ember';
+import { computed } from 'ember-decorators/object';
+import { module, test } from 'qunit';
+
+import { SUPPORTS_NEW_COMPUTED } from 'ember-compatibility-helpers';
+
+const { get, set } = Ember;
+
+module('new computed property style (get/set functions)');
+
+if (SUPPORTS_NEW_COMPUTED) {
+  test('allows using ember-new-computed style get/set syntax', function(assert) {
+    // not currently supported by Babel (waiting on confirmation from @wycats
+    // before opening an issue)
+    let setCallCount = 0;
+    let getCallCount = 0;
+    let obj = {
+      first: 'rob',
+      last: 'jackson',
+
+      @computed('first', 'last')
+      name: {
+        get(first, last) {
+          assert.equal(first, 'rob');
+          assert.equal(last, 'jackson');
+
+          getCallCount++;
+        },
+
+        set(value, first, last) {
+          assert.equal(first, 'rob');
+          assert.equal(last, 'jackson');
+
+          setCallCount++;
+
+          return `${value}-transformed`;
+        }
+      }
+    };
+
+    get(obj, 'name');
+    assert.equal(getCallCount, 1, 'calls getter initially');
+
+    get(obj, 'name');
+    assert.equal(getCallCount, 1, 'does not call getter when cache is not busted');
+
+    set(obj, 'name', 'foo');
+    assert.equal(setCallCount, 1, 'calls setter when set');
+
+    assert.strictEqual(get(obj, 'name'), 'foo-transformed', 'return value of setter is new value of computed property')
+  });
+
+  test('attr.foo passes attr.foo', function(assert) {
+    assert.expect(2);
+
+    let obj = {
+      attr: {
+        foo: 'bar'
+      },
+
+      @computed('attr.foo')
+      something: {
+        get(foo) {
+          assert.deepEqual(foo, 'bar');
+        },
+        set(value, foo) {
+          assert.deepEqual(foo, 'bar');
+        }
+      },
+    };
+
+    get(obj, 'something');
+    set(obj, 'something', 'something');
+  });
+
+  test('attr.models.@each passes attr.models', function(assert) {
+    assert.expect(2);
+
+    let obj = {
+      attr: {
+        models: ['one', 'two']
+      },
+
+      @computed('attr.models.@each.length')
+      something: {
+        get(models) {
+          assert.deepEqual(models, ['one', 'two']);
+        },
+        set(value, models) {
+          assert.deepEqual(models, ['one', 'two']);
+        }
+      },
+    };
+
+    get(obj, 'something');
+    set(obj, 'something', 'something');
+  });
+
+  test('attr.models.[] passes attr.models', function(assert) {
+    assert.expect(2);
+
+    let obj = {
+      models: ['one', 'two'],
+
+      @computed('models.[]')
+      something: {
+        get(models) {
+          assert.deepEqual(models, ['one', 'two']);
+        },
+        set(value, models) {
+          assert.deepEqual(models, ['one', 'two']);
+        }
+      },
+    };
+
+    get(obj, 'something');
+    set(obj, 'something', 'something');
+  });
+
+  test('attr.{foo,bar} passes attr.foo and attr.bar', function(assert) {
+    assert.expect(4);
+
+    let obj = {
+      attr: {
+        foo: 'foo',
+        bar: 'bar'
+      },
+
+      @computed('attr.{foo,bar}')
+      something: {
+        get(foo, bar) {
+          assert.equal(foo, 'foo');
+          assert.equal(bar, 'bar');
+        },
+        set(value, foo, bar) {
+          assert.equal(foo, 'foo');
+          assert.equal(bar, 'bar');
+        }
+      },
+    };
+
+    get(obj, 'something');
+    set(obj, 'something', 'something');
+  });
+
+  test('attr.@each.{foo,bar} passes attr', function(assert) {
+    assert.expect(2);
+
+    let obj = {
+      attr: [{
+        foo: 'foo',
+        bar: 'bar'
+      }],
+
+      @computed('attr.@each.{foo,bar}')
+      something: {
+        get(models) {
+          assert.deepEqual(models, [{ foo: 'foo', bar: 'bar' }]);
+        },
+        set(value, models) {
+          assert.deepEqual(models, [{ foo: 'foo', bar: 'bar' }]);
+        }
+      },
+    };
+
+    get(obj, 'something');
+    set(obj, 'something', 'something');
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -581,6 +581,12 @@ babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.10:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-debug-macros@^0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.11.tgz#6c562bf561fccd406ce14ab04f42c218cf956605"
+  dependencies:
+    semver "^5.3.0"
+
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
@@ -2452,6 +2458,14 @@ ember-cli@2.13.2:
     validate-npm-package-name "^3.0.0"
     walk-sync "^0.3.0"
     yam "0.0.22"
+
+ember-compatibility-helpers@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.0.tgz#52dbe15fd67cd357fdf3d2bdb1221467c87947c3"
+  dependencies:
+    babel-plugin-debug-macros "^0.1.11"
+    ember-cli-version-checker "^2.0.0"
+    semver "^5.4.1"
 
 ember-data@~2.13.0:
   version "2.13.2"
@@ -5355,6 +5369,10 @@ semver@^4.1.0, semver@^4.3.1:
 semver@^5.1.0, semver@^5.1.1, semver@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 send@0.15.3:
   version "0.15.3"


### PR DESCRIPTION
Adds ember-try scenarios for 1.11 and 1.13, and adds `ember-compatibility-helpers` which gives us build time flags for Ember feature detection. This means we can write forward/backwards compatible code with absolutely no dead weight added to production builds of consuming applications.

@rwjblue I included the fix for getters/setters, if you find time to update the polyfill I'll update the compat helpers and remove the fallback