### PR TITLE
@sort regression when used with property for sort args

### DIFF
--- a/addon/object/computed.js
+++ b/addon/object/computed.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import { assert } from '@ember/debug';
 import {
   decoratedPropertyWithRequiredParams,
-  decoratedPropertyWithOptionalCallback
+  decoratedPropertyWithOptionalCallback,
+  decoratedPropertyWithEitherCallbackOrProperty
 } from '../utils/decorator-macros';
 
 import {
@@ -711,7 +712,7 @@ export const setDiff = decoratedPropertyWithRequiredParams(Ember.computed.setDif
  * @param {String} dependentKey - The key for the array that should be sorted
  * @param {Array<String>|Function(Any, Any): Number} sortDefinition - Sorting function or sort descriptor
  */
-export const sort = decoratedPropertyWithOptionalCallback(Ember.computed.sort);
+export const sort = decoratedPropertyWithEitherCallbackOrProperty(Ember.computed.sort);
 
 /**
  * Decorator that wraps [Ember.computed.sum](http://emberjs.com/api/classes/Ember.computed.html#method_sum)

--- a/addon/utils/decorator-macros.js
+++ b/addon/utils/decorator-macros.js
@@ -1,3 +1,5 @@
+import { IS_EMBER_2 } from 'ember-compatibility-helpers';
+
 import { decoratorWithParams } from './decorator-wrappers';
 import extractValue from './extract-value';
 
@@ -56,7 +58,7 @@ export function decoratedPropertyWithEitherCallbackOrProperty(fn) {
       return fn(...params);
     }
 
-    if (params.length > 1 && lastParamType === 'string') {
+    if (IS_EMBER_2 && params.length > 1 && lastParamType === 'string') {
       assert(`Cannot use '${lastParam}' on field '${key}' because it does not exist on the target`, target[lastParam]);
       return fn(...params);
     }

--- a/addon/utils/decorator-macros.js
+++ b/addon/utils/decorator-macros.js
@@ -50,12 +50,13 @@ export function decoratedPropertyWithEitherCallbackOrProperty(fn) {
     assert(`Cannot use '${fn.name}' on field '${key}' without parameters`, params.length !== 0);
 
     const lastParam = params[params.length - 1]
+    const lastParamType = typeof lastParam;
 
-    if (typeof lastParam === 'function') {
+    if (lastParamType === 'function') {
       return fn(...params);
     }
 
-    if (params.length > 1 && typeof lastParam === 'string') {
+    if (params.length > 1 && lastParamType === 'string') {
       assert(`Cannot use '${lastParam}' on field '${key}' because it does not exist on the target`, target[lastParam]);
       return fn(...params);
     }

--- a/addon/utils/decorator-macros.js
+++ b/addon/utils/decorator-macros.js
@@ -43,7 +43,7 @@ export function decoratedPropertyWithOptionalCallback(fn) {
     }
 
     const value = extractValue(desc);
-    assert(`Cannot use '${fn.name}' on field '${key}' without a callback`, (typeof value === 'function'));
+    assert(`Cannot use '${fn.name}' on field '${key}' without a callback`, typeof value === 'function');
 
     return fn(...params, value);
   });

--- a/addon/utils/decorator-macros.js
+++ b/addon/utils/decorator-macros.js
@@ -38,8 +38,12 @@ export function decoratedPropertyWithOptionalCallback(fn) {
       return fn(...params);
     }
 
+    if (typeof params[params.length - 1] === 'string' && target[params[params.length - 1]]) {
+      return fn(...params);
+    }
+
     const value = extractValue(desc);
-    assert(`Cannot use '${fn.name}' on field '${key}' without a callback`, typeof value === 'function');
+    assert(`Cannot use '${fn.name}' on field '${key}' without a callback`, (typeof value === 'function'));
 
     return fn(...params, value);
   });

--- a/addon/utils/decorator-macros.js
+++ b/addon/utils/decorator-macros.js
@@ -38,7 +38,25 @@ export function decoratedPropertyWithOptionalCallback(fn) {
       return fn(...params);
     }
 
-    if (typeof params[params.length - 1] === 'string' && target[params[params.length - 1]]) {
+    const value = extractValue(desc);
+    assert(`Cannot use '${fn.name}' on field '${key}' without a callback`, typeof value === 'function');
+
+    return fn(...params, value);
+  });
+}
+
+export function decoratedPropertyWithEitherCallbackOrProperty(fn) {
+  return decoratorWithParams(function(target, key, desc, params) {
+    assert(`Cannot use '${fn.name}' on field '${key}' without parameters`, params.length !== 0);
+
+    const lastParam = params[params.length - 1]
+
+    if (typeof lastParam === 'function') {
+      return fn(...params);
+    }
+
+    if (params.length > 1 && typeof lastParam === 'string') {
+      assert(`Cannot use '${lastParam}' on field '${key}' because it does not exist on the target`, target[lastParam]);
       return fn(...params);
     }
 

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -1,7 +1,5 @@
 import Ember from 'ember';
 import { computed, readOnly } from 'ember-decorators/object';
-import { sort } from 'ember-decorators/object/computed';
-
 import { module, test } from 'qunit';
 
 const { get, set, setProperties } = Ember;
@@ -38,19 +36,6 @@ test('dependent key changes invalidate the computed property', function(assert) 
   set(obj, 'first', 'al');
   assert.equal(get(obj, 'name'), 'al jackson');
 });
-
-test('sorts on the keys defined in another property', function(assert) {
-  var obj = {
-    arr: [{ name: 'b' }, { name: 'a' }, { name: 'd' }, { name: 'c' }],
-    sortProp: ['name:asc'],
-
-    @sort('arr', 'sortProp') sorted: null
-  }
-
-  var expected = [{ name: 'a' }, { name: 'b' }, { name: 'c' }, { name: 'd' }];
-  assert.deepEqual(get(obj, 'sorted'), expected);
-});
-
 
 test('readOnly', function(assert) {
   var obj = {

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -48,7 +48,7 @@ test('sorts on the keys defined in another property', function(assert) {
   }
 
   var expected = [{ name: 'a' }, { name: 'b' }, { name: 'c' }, { name: 'd' }];
-  assert.equal(get(obj, 'sorted'), expected);
+  assert.deepEqual(get(obj, 'sorted'), expected);
 });
 
 

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -37,6 +37,7 @@ test('dependent key changes invalidate the computed property', function(assert) 
   assert.equal(get(obj, 'name'), 'al jackson');
 });
 
+
 test('readOnly', function(assert) {
   var obj = {
     first: 'rob',

--- a/tests/unit/computed-test.js
+++ b/tests/unit/computed-test.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 import { computed, readOnly } from 'ember-decorators/object';
+import { sort } from 'ember-decorators/object/computed';
+
 import { module, test } from 'qunit';
 
 const { get, set, setProperties } = Ember;
@@ -35,6 +37,18 @@ test('dependent key changes invalidate the computed property', function(assert) 
   assert.equal(get(obj, 'name'), 'rob jackson');
   set(obj, 'first', 'al');
   assert.equal(get(obj, 'name'), 'al jackson');
+});
+
+test('sorts on the keys defined in another property', function(assert) {
+  var obj = {
+    arr: [{ name: 'b' }, { name: 'a' }, { name: 'd' }, { name: 'c' }],
+    sortProp: ['name:asc'],
+
+    @sort('arr', 'sortProp') sorted: null
+  }
+
+  var expected = [{ name: 'a' }, { name: 'b' }, { name: 'c' }, { name: 'd' }];
+  assert.equal(get(obj, 'sorted'), expected);
 });
 
 

--- a/tests/unit/macro-test.js
+++ b/tests/unit/macro-test.js
@@ -588,6 +588,16 @@ test('sort (no callback, use property value)', function(assert) {
   assert.deepEqual(actual, ['a','b','foo','z']);
 });
 
+test('sort (no callback, use non-existing property value)', function(assert) {
+  assert.throws(() => {
+    Ember.Object.extend({
+      @sort('names', 'sorts')
+      sortedNames: null
+    }).create();
+  }, /sorts/, /sortedNames/, 'because it does not exist on the target');
+});
+
+
 test('sum', function(assert) {
   var obj = Ember.Object.extend({
     init() {

--- a/tests/unit/macro-test.js
+++ b/tests/unit/macro-test.js
@@ -584,7 +584,8 @@ test('sort (no callback, use property value)', function(assert) {
     sortedNames: null
   }).create();
 
-  assert.deepEqual(obj.get('sortedNames').mapBy('name'), ['a','b','foo','z']);
+  var actual = obj.get('sortedNames').mapBy('name');
+  assert.deepEqual(actual, ['a','b','foo','z']);
 });
 
 test('sum', function(assert) {

--- a/tests/unit/macro-test.js
+++ b/tests/unit/macro-test.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
+import { IS_EMBER_2 } from 'ember-compatibility-helpers';
+
 import {
   alias,
   and,
@@ -572,30 +574,32 @@ test('sort (no callback, use descriptor value)', function(assert) {
   assert.deepEqual(obj.get('sortedNames').mapBy('name'), ['a','b','foo','z']);
 });
 
-test('sort (no callback, use property value)', function(assert) {
-  var obj = Ember.Object.extend({
-    init() {
-      this._super(...arguments);
-      this.names = Ember.A([{name:'b'},{name:'z'},{name:'a'},{name:'foo'}]);
-    },
+if (IS_EMBER_2) {
+  test('sort (no callback, use property value)', function(assert) {
+    var obj = Ember.Object.extend({
+      init() {
+        this._super(...arguments);
+        this.names = Ember.A([{name:'b'},{name:'z'},{name:'a'},{name:'foo'}]);
+      },
 
-    sorts: ['name:asc'],
-    @sort('names', 'sorts')
-    sortedNames: null
-  }).create();
-
-  var actual = obj.get('sortedNames').mapBy('name');
-  assert.deepEqual(actual, ['a','b','foo','z']);
-});
-
-test('sort (no callback, use non-existing property value)', function(assert) {
-  assert.throws(() => {
-    Ember.Object.extend({
+      sorts: ['name:asc'],
       @sort('names', 'sorts')
       sortedNames: null
     }).create();
-  }, /sorts/, /sortedNames/, 'because it does not exist on the target');
-});
+
+    var actual = obj.get('sortedNames').mapBy('name');
+    assert.deepEqual(actual, ['a','b','foo','z']);
+  });
+
+  test('sort (no callback, use non-existing property value)', function(assert) {
+    assert.throws(() => {
+      Ember.Object.extend({
+        @sort('names', 'sorts')
+        sortedNames: null
+      }).create();
+    }, /sorts/, /sortedNames/, 'because it does not exist on the target');
+  });
+}
 
 
 test('sum', function(assert) {

--- a/tests/unit/macro-test.js
+++ b/tests/unit/macro-test.js
@@ -572,6 +572,21 @@ test('sort (no callback, use descriptor value)', function(assert) {
   assert.deepEqual(obj.get('sortedNames').mapBy('name'), ['a','b','foo','z']);
 });
 
+test('sort (no callback, use property value)', function(assert) {
+  var obj = Ember.Object.extend({
+    init() {
+      this._super(...arguments);
+      this.names = Ember.A([{name:'b'},{name:'z'},{name:'a'},{name:'foo'}]);
+    },
+
+    sorts: ['name:asc'],
+    @sort('names', 'sorts')
+    sortedNames: null
+  }).create();
+
+  assert.deepEqual(obj.get('sortedNames').mapBy('name'), ['a','b','foo','z']);
+});
+
 test('sum', function(assert) {
   var obj = Ember.Object.extend({
     init() {


### PR DESCRIPTION
Related Issue: https://github.com/ember-decorators/ember-decorators/issues/158

This used to work:
```js
  sortBy: 'registeredAt:asc',
  @sort('model.registrations', 'sortBy') registrations: null,
```

but now it gives the error 
 `Assertion Failed: Cannot use 'sort' on field 'registrations' without a callback`

the only way to solve this is to use a full function for the comparator:

```js
  @sort('model.registrations', function(a, b) {
    const ra = a.get('registeredAt');
    const rb = b.get('registeredAt');

    return (ra > rb && 1) || (ra < rb && -1) || 0;
  }) registrations;
```

This PR restores the previous behavior