### PR TITLE
feature(component): Adds component decorators

### DIFF
--- a/addon/component/index.js
+++ b/addon/component/index.js
@@ -1,0 +1,114 @@
+import { assert } from '@ember/debug';
+
+import collapseProto from '../utils/collapse-proto';
+import { decoratedConcatenatedProperty } from '../utils/decorator-macros';
+
+/**
+ * Decorator which indicates that the field or computed should be bound
+ * to an attribute value on the component. This replaces `attributeBindings`
+ * by directly allowing you to specify which properties should be bound.
+ *
+ * ```js
+ * import Component from '@ember/component';
+ * import { attribute } from 'ember-decorators/component';
+ * import { computed } from 'ember-decorators/object';
+ *
+ * export default class AttributeDemoComponent extends Component {
+ *   @attribute role = 'button';
+ *
+ *   @attribute
+ *   @computed
+ *   get id() {
+ *     // return generated id
+ *   }
+ * }
+ * ```
+ *
+ * @function
+ */
+export const attribute = decoratedConcatenatedProperty('attributeBindings');
+
+/**
+ * Decorator which indicates that the field or computed should be bound to
+ * the component class names. This replaces `classNameBindings` by directly
+ * allowing you to specify which properties should be bound.
+ *
+ * ```js
+ * import Component from '@ember/component';
+ * import { className } from 'ember-decorators/component';
+ * import { computed } from 'ember-decorators/object';
+ *
+ * export default class ClassNameDemoComponent extends Component {
+ *   @className boundField = 'default-class';
+ *
+ *   @className
+ *   @computed
+ *   get boundComputed() {
+ *     // return generated class
+ *   }
+ * }
+ * ```
+ *
+ * @function
+ */
+export const className = decoratedConcatenatedProperty('classNameBindings');
+
+/**
+ * Class decorator which specifies the class names to be applied to a component.
+ * This replaces the `classNames` property on components in the traditional Ember
+ * object model.
+ *
+ * ```js
+ * import Component from '@ember/component';
+ * import { classNames } from 'ember-decorators/component';
+ *
+ * @classNames('a-static-class', 'another-static-class')
+ * export default class ClassNamesDemoComponent extends Component {}
+ * ```
+ *
+ * @param {...String} classNames - The list of classes to be applied to the component
+ */
+export function classNames(...classNames) {
+  assert(`The @classNames decorator must be provided strings, received: ${classNames}`, classNames.reduce((allStrings, name) => {
+    return allStrings && typeof name === 'string'
+  }, true));
+
+  return function(klass) {
+    let { prototype } = klass;
+
+    collapseProto(prototype);
+
+    if ('classNames' in prototype) {
+      let parentClasses = prototype.classNames;
+      classNames.unshift(...parentClasses);
+    }
+
+    prototype.classNames = classNames;
+
+    return klass;
+  }
+}
+
+/**
+ * Class decorator which specifies the tag name of the component. This replaces
+ * the `tagName` property on components in the traditional Ember object model.
+ *
+ * ```js
+ * import Component from '@ember/component';
+ * import { tagName } from 'ember-decorators/component';
+ *
+ * @tagName('button')
+ * export default class TagNameDemoComponent extends Component {}
+ * ```
+ *
+ * @param {String} tagName - The HTML tag to be used for the component
+ */
+export function tagName(tagName) {
+  assert(`The @tagName decorator must be provided exactly one argument, received: ${tagName}`, arguments.length === 1);
+  assert(`The @tagName decorator must be provided a string, received: ${tagName}`, typeof tagName === 'string');
+
+  return function(klass) {
+    klass.prototype.tagName = tagName;
+    return klass;
+  }
+}

--- a/addon/object/index.js
+++ b/addon/object/index.js
@@ -3,6 +3,7 @@ import { DEBUG } from '@glimmer/env';
 import Ember from 'ember';
 import macroComputed from 'ember-macro-helpers/computed';
 
+import collapseProto from '../utils/collapse-proto';
 import extractValue from '../utils/extract-value';
 import {
   decorator,
@@ -49,14 +50,7 @@ export const action = decorator(function(target, key, desc) {
 
   assert('The @action decorator must be applied to functions', typeof value === 'function');
 
-  // We must collapse the superclass prototype to make sure that the `actions`
-  // object will exist. Since collapsing doesn't generally happen until a class is
-  // instantiated, we have to do it manually.
-  let superClass = Object.getPrototypeOf(target.constructor);
-
-  if (superClass.hasOwnProperty('proto') && typeof superClass.proto === 'function') {
-    superClass.proto();
-  }
+  collapseProto(target);
 
   if (HAS_UNDERSCORE_ACTIONS) {
     if (!target.hasOwnProperty('_actions')) {

--- a/addon/utils/collapse-proto.js
+++ b/addon/utils/collapse-proto.js
@@ -1,0 +1,10 @@
+export default function collapseProto(target) {
+  // We must collapse the superclass prototype to make sure that the `actions`
+  // object will exist. Since collapsing doesn't generally happen until a class is
+  // instantiated, we have to do it manually.
+  let superClass = Object.getPrototypeOf(target.constructor);
+
+  if (superClass.hasOwnProperty('proto') && typeof superClass.proto === 'function') {
+    superClass.proto();
+  }
+}

--- a/tests/unit/component/attribute-test.js
+++ b/tests/unit/component/attribute-test.js
@@ -1,0 +1,107 @@
+import Ember from 'ember';
+import { attribute } from 'ember-decorators/component';
+import { computed } from 'ember-decorators/object';
+
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent } from 'ember-qunit';
+import { test } from 'qunit';
+import { find, findAll } from 'ember-native-dom-helpers';
+
+moduleForComponent('attributes', { integration: true });
+
+test('decorator adds attributes to component', function(assert) {
+  class FooComponent extends Ember.Component {
+    @attribute role = 'button';
+
+    @attribute
+    @computed
+    get id() {
+      return 'bar';
+    }
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.render(hbs`{{foo-component}}`);
+
+  assert.ok(find('[role="button"]'));
+  assert.ok(find('#bar'));
+});
+
+test('decorator does not add attribute to superclass', function(assert) {
+  class FooComponent extends Ember.Component {
+    @attribute role = 'button';
+  }
+
+  class BarComponent extends FooComponent {
+    @attribute id = 'bar';
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.register('component:bar-component', BarComponent);
+  this.register('template:components/bar-component', hbs`Hello, moon!`);
+
+  this.render(hbs`{{foo-component}}{{bar-component}}`)
+
+  assert.equal(findAll('[role="button"]').length, 2);
+  assert.equal(findAll('#bar').length, 1);
+});
+
+test('decorator works correctly through traditional and ES6 hierarchy', function(assert) {
+  const FooComponent = Ember.Component.extend({
+    attributeBindings: ['role'],
+    role: 'button'
+  });
+
+  class BarComponent extends FooComponent {
+    @attribute id = 'bar';
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.register('component:bar-component', BarComponent);
+  this.register('template:components/bar-component', hbs`Hello, moon!`);
+
+  this.render(hbs`{{foo-component}}{{bar-component}}`)
+
+  assert.equal(findAll('[role="button"]').length, 2);
+  assert.equal(findAll('#bar').length, 1);
+});
+
+test('decorator allows attributes to be overriden', function(assert) {
+  class FooComponent extends Ember.Component {
+    @attribute role = 'button';
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.render(hbs`{{foo-component role="list"}}`)
+
+  assert.ok(find('[role="list"]'));
+});
+
+test('decorator allows attributes to be overriden by subclasses', function(assert) {
+  class FooComponent extends Ember.Component {
+    @attribute role = 'button';
+  }
+
+  class BarComponent extends FooComponent {
+    @attribute role = 'list';
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.register('component:bar-component', BarComponent);
+  this.register('template:components/bar-component', hbs`Hello, moon!`);
+
+  this.render(hbs`{{foo-component}}{{bar-component}}`)
+
+  assert.equal(findAll('[role="button"]').length, 1);
+  assert.equal(findAll('[role="list"]').length, 1);
+});

--- a/tests/unit/component/class-name-test.js
+++ b/tests/unit/component/class-name-test.js
@@ -1,0 +1,116 @@
+import Ember from 'ember';
+import { className } from 'ember-decorators/component';
+import { computed } from 'ember-decorators/object';
+
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent } from 'ember-qunit';
+import { test } from 'qunit';
+import { find, findAll } from 'ember-native-dom-helpers';
+
+moduleForComponent('className', { integration: true });
+
+test('decorator adds class to component', function(assert) {
+  class FooComponent extends Ember.Component {
+    @className foo = 'foo';
+
+    @className
+    @computed
+    get bar() {
+      return 'bar';
+    }
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.render(hbs`{{foo-component}}`);
+
+  assert.ok(find('.foo'));
+  assert.ok(find('.bar'));
+});
+
+
+test('decorator does not add class to superclass', function(assert) {
+  class FooComponent extends Ember.Component {
+    @className foo = 'foo';
+  }
+
+  class BarComponent extends FooComponent {
+    @className
+    @computed
+    get bar() {
+      return 'bar';
+    }
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.register('component:bar-component', BarComponent);
+  this.register('template:components/bar-component', hbs`Hello, moon!`);
+
+  this.render(hbs`{{foo-component}}{{bar-component}}`)
+
+  assert.equal(findAll('.foo').length, 2);
+  assert.equal(findAll('.bar').length, 1);
+});
+
+test('decorator works correctly through traditional and ES6 hierarchy', function(assert) {
+  const FooComponent = Ember.Component.extend({
+    classNameBindings: ['foo'],
+    foo: 'foo'
+  });
+
+  class BarComponent extends FooComponent {
+    @className
+    @computed
+    get bar() {
+      return 'bar';
+    }
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.register('component:bar-component', BarComponent);
+  this.register('template:components/bar-component', hbs`Hello, moon!`);
+
+  this.render(hbs`{{foo-component}}{{bar-component}}`)
+
+  assert.equal(findAll('.foo').length, 2);
+  assert.equal(findAll('.bar').length, 1);
+});
+
+test('decorator allows attributes to be overriden', function(assert) {
+  class FooComponent extends Ember.Component {
+    @className foo = 'foo';
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.render(hbs`{{foo-component foo="bar"}}`)
+
+  assert.ok(find('.bar'));
+});
+
+test('decorator allows attributes to be overriden by subclasses', function(assert) {
+  class FooComponent extends Ember.Component {
+    @className foo = 'foo';
+  }
+
+  class BarComponent extends FooComponent {
+    @className foo = 'bar';
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.register('component:bar-component', BarComponent);
+  this.register('template:components/bar-component', hbs`Hello, moon!`);
+
+  this.render(hbs`{{foo-component}}{{bar-component}}`)
+
+  assert.equal(findAll('.foo').length, 1);
+  assert.equal(findAll('.bar').length, 1);
+});

--- a/tests/unit/component/class-names-test.js
+++ b/tests/unit/component/class-names-test.js
@@ -1,0 +1,74 @@
+import Ember from 'ember';
+import { classNames } from 'ember-decorators/component';
+
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent } from 'ember-qunit';
+import { test } from 'qunit';
+import { find, findAll } from 'ember-native-dom-helpers';
+
+moduleForComponent('classNames', { integration: true });
+
+test('decorator adds class to component', function(assert) {
+  @classNames('foo')
+  class FooComponent extends Ember.Component {}
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.render(hbs`{{foo-component}}`);
+
+  assert.ok(find('.foo'));
+});
+
+
+test('decorator does not add class to superclass', function(assert) {
+  @classNames('foo')
+  class FooComponent extends Ember.Component {}
+
+  @classNames('bar')
+  class BarComponent extends FooComponent {}
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.register('component:bar-component', BarComponent);
+  this.register('template:components/bar-component', hbs`Hello, moon!`);
+
+  this.render(hbs`{{foo-component}}{{bar-component}}`)
+
+  assert.equal(findAll('.foo').length, 2);
+  assert.equal(findAll('.bar').length, 1);
+});
+
+test('decorator works correctly through traditional and ES6 hierarchy', function(assert) {
+  const FooComponent = Ember.Component.extend({
+    classNames: ['foo']
+  });
+
+  @classNames('bar')
+  class BarComponent extends FooComponent {}
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.register('component:bar-component', BarComponent);
+  this.register('template:components/bar-component', hbs`Hello, moon!`);
+
+  this.render(hbs`{{foo-component}}{{bar-component}}`)
+
+  assert.equal(findAll('.foo').length, 2);
+  assert.equal(findAll('.bar').length, 1);
+});
+
+test('decorator throws an error if given non-string values', function(assert) {
+  assert.throws(
+    () => {
+      @classNames(1, true, {})
+      class FooComponent extends Ember.Component {}
+
+      new FooComponent();
+    },
+    /The @classNames decorator must be provided strings, received:/,
+    'error thrown correctly'
+  )
+});

--- a/tests/unit/component/tag-name-test.js
+++ b/tests/unit/component/tag-name-test.js
@@ -1,0 +1,71 @@
+import Ember from 'ember';
+import { tagName } from 'ember-decorators/component';
+
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent } from 'ember-qunit';
+import { test } from 'qunit';
+import { find } from 'ember-native-dom-helpers';
+
+moduleForComponent('tagName', { integration: true });
+
+test('decorator sets tag of component', function(assert) {
+  @tagName('foo')
+  class FooComponent extends Ember.Component {}
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.render(hbs`{{foo-component}}`);
+
+  assert.ok(find('foo'));
+});
+
+test('decorator throws an error if given a non-string value', function(assert) {
+  assert.throws(
+    () => {
+      @tagName(true)
+      class FooComponent extends Ember.Component {}
+
+      new FooComponent();
+    },
+    /The @tagName decorator must be provided a string/,
+    'error thrown correctly'
+  )
+});
+
+test('decorator throws an error if given more than one value', function(assert) {
+  assert.throws(
+    () => {
+      @tagName('foo', 'bar')
+      class FooComponent extends Ember.Component {}
+
+      new FooComponent();
+    },
+    /The @tagName decorator must be provided exactly one argument/,
+    'error thrown correctly'
+  )
+});
+
+test('decorator throws an error if given no values', function(assert) {
+  assert.throws(
+    () => {
+      @tagName
+      class FooComponent extends Ember.Component {}
+
+      new FooComponent();
+    },
+    /The @tagName decorator must be provided a string/, // Fails the string test because the class is passed in directly
+    'error thrown correctly'
+  )
+
+  assert.throws(
+    () => {
+      @tagName()
+      class FooComponent extends Ember.Component {}
+
+      new FooComponent();
+    },
+    /The @tagName decorator must be provided exactly one argument/,
+    'error thrown correctly'
+  )
+});


### PR DESCRIPTION
Adds decorators for tagName, classNames, classNameBindings, and attributeBindings. These fields, for a variety of reasons, have special behavior when compared to other class fields such as merging, concatenating, or simply having to be applied to the prototype/before init. These decorators provide easy to use, declarative alternatives which should tide us over until we are able to drop them altogether (with Glimmer components).

* `@attribute`: Declares a field an `attributeBinding` and adds it to the array
* `@className`: Declares a field a `classNameBinding` and adds it to the array
* `@classNames`: Adds the class names to the component
* `@tagName`: Specifies the tag of the component