### PR TITLE
feature(legacy): Transform `constructor` into `init` for legacy support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+// launch.json
+{
+  "version": "0.2.0",
+  "configurations": [
+
+  {
+    "type": "node",
+    "request": "launch",
+    "name": "Ember Build",
+    "program": "${workspaceRoot}/node_modules/ember-cli/bin/ember",
+    "args": [
+      "build"
+    ]
+  },
+  {
+    "type": "node",
+    "request": "launch",
+    "name": "Ember Serve",
+    "program": "${workspaceRoot}/node_modules/ember-cli/bin/ember",
+    "args": [
+      "serve"
+    ]
+  }
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -57,11 +57,13 @@ module.exports = {
     let disableTransforms = parentOptions.emberDecorators && parentOptions.emberDecorators.disableTransforms;
 
     if (!this._registeredWithBabel && !disableTransforms) {
-      let checker = new VersionChecker(this.parent).for('ember-cli-babel', 'npm');
+      let emberChecker = new VersionChecker(this.app).forEmber();
+      let babelChecker = new VersionChecker(this.parent).for('ember-cli-babel', 'npm');
 
-      if (checker.satisfies('^6.0.0-beta.1')) {
+      if (babelChecker.satisfies('^6.0.0-beta.1')) {
         let TransformDecoratorsLegacy = requireTransform('babel-plugin-transform-decorators-legacy');
         let TransformClassProperties = requireTransform('babel-plugin-transform-class-properties');
+        let EmberLegacyClassConstructor = requireTransform('babel-plugin-ember-legacy-class-constructor');
 
         // Create babel options if they do not exist
         parentOptions.babel = parentOptions.babel || {};
@@ -76,6 +78,10 @@ module.exports = {
 
         if (!hasPlugin('transform-class-properties')) {
           plugins.push(TransformClassProperties);
+        }
+
+        if (!emberChecker.isAbove('2.13.0') && !hasPlugin('ember-legacy-class-constructor')) {
+          plugins.push(EmberLegacyClassConstructor);
         }
       } else {
         app.project.ui.writeWarnLine(

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-ember-legacy-class-constructor": "^0.1.1",
     "ember-cli-babel": "^6.0.0",
     "ember-cli-version-checker": "^2.0.0",
     "ember-compatibility-helpers": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,6 +606,10 @@ babel-plugin-debug-macros@^0.1.11:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-ember-legacy-class-constructor@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-legacy-class-constructor/-/babel-plugin-ember-legacy-class-constructor-0.1.1.tgz#c5e9759a79334d48e5936bcd3593ccf48215299e"
+
 babel-plugin-ember-modules-api-polyfill@^1.5.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.6.0.tgz#abd1afa4237b3121cb51222f9bf3283cad8990aa"


### PR DESCRIPTION
After dealing with a lot of the edge cases caused by the double-extends injections messing up `constructor`, we're finding that it introduces a lot of overhead and makes ES classes difficult to use. For an example, check out #166, where tests are failing due to the difference in behavior between versions.

This PR introduces a new babel transform for legacy versions of Ember. It renames the `constructor` functions to `init`, allowing class fields and other constructor based features to work as intended. A default constructor that calls `init` is put in place as well to make sure non-Ember Object classes aren't broken.

I think this transform could a separate addon too, open to pulling it out and letting users decide whether or not they want this. I think for writing tests it's going to be invaluable, the amount of branching logic depending on versions will be huge otherwise.