### PR TITLE
feat(validations): Adds attribute meta info for @attribute and @className

### DIFF
--- a/addon/utils/decorator-macros.js
+++ b/addon/utils/decorator-macros.js
@@ -1,4 +1,6 @@
 import { IS_EMBER_2 } from 'ember-compatibility-helpers';
+import { validationsForKey } from '@ember-decorators/utils/debug';
+
 
 import { decoratorWithParams } from './decorator-wrappers';
 import extractValue from './extract-value';
@@ -72,6 +74,10 @@ export function decoratedPropertyWithEitherCallbackOrProperty(fn) {
 
 export function decoratedConcatenatedProperty(concatProperty) {
   return function(target, key, desc) {
+    // Set these properties as attributes in validation meta so validation
+    // libraries know how to treat them if they are passed into the component
+    validationsForKey(target, key).isAttribute = true;
+
     // Make sure the descriptor is correctly defined, defaults to false
     desc.writable = true;
     desc.configurable = true;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "@ember-decorators/utils": "^0.1.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "ember-cli-babel": "^6.0.0",

--- a/tests/unit/component/attribute-test.js
+++ b/tests/unit/component/attribute-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { attribute } from 'ember-decorators/component';
 import { computed } from 'ember-decorators/object';
+import { validationsForKey } from '@ember-decorators/utils/debug';
 
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent } from 'ember-qunit';
@@ -119,4 +120,12 @@ test('decorator allows attributes to be overriden by subclasses', function(asser
 
   assert.equal(findAll('[role="button"]').length, 1);
   assert.equal(findAll('[role="list"]').length, 1);
+});
+
+test('marks itself as an attribute in validations meta', function(assert) {
+  class FooComponent extends Ember.Component {
+    @attribute role = 'button';
+  }
+
+  assert.equal(validationsForKey(FooComponent.prototype, 'role').isAttribute, true);
 });

--- a/tests/unit/component/class-name-test.js
+++ b/tests/unit/component/class-name-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { className } from 'ember-decorators/component';
 import { computed } from 'ember-decorators/object';
+import { validationsForKey } from '@ember-decorators/utils/debug';
 
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent } from 'ember-qunit';
@@ -127,4 +128,12 @@ test('decorator allows attributes to be overriden by subclasses', function(asser
 
   assert.equal(findAll('.foo').length, 1);
   assert.equal(findAll('.bar').length, 1);
+});
+
+test('marks itself as an attribute in validations meta', function(assert) {
+  class FooComponent extends Ember.Component {
+    @className foo = 'foo';
+  }
+
+  assert.equal(validationsForKey(FooComponent.prototype, 'foo').isAttribute, true);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ember-decorators/utils@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@ember-decorators/utils/-/utils-0.1.1.tgz#1b8b054a3b0ecfa3ea1f58c5313a4e8a4742e22a"
+  dependencies:
+    babel-plugin-filter-imports "^1.0.4"
+    broccoli-funnel "^2.0.1"
+    ember-cli-babel "^6.3.0"
+
 "@glimmer/compiler@^0.22.3":
   version "0.22.3"
   resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.22.3.tgz#3aef9448460af1d320a82423323498a6ff38a0c6"
@@ -612,6 +620,12 @@ babel-plugin-ember-modules-api-polyfill@^1.5.1:
   dependencies:
     ember-rfc176-data "^0.2.0"
 
+babel-plugin-ember-modules-api-polyfill@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.1.0.tgz#78848cc4fcc2274882a6c15cbb23fefcdc771301"
+  dependencies:
+    ember-rfc176-data "^0.3.0"
+
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
@@ -623,6 +637,13 @@ babel-plugin-feature-flags@^0.3.1:
 babel-plugin-filter-imports@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-0.3.1.tgz#e7859b56886b175dd2616425d277b219e209ea8b"
+
+babel-plugin-filter-imports@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-1.0.4.tgz#356aea4f8d3ec5a2cc69d7c916daeb8f554c6f7c"
+  dependencies:
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
 
 babel-plugin-htmlbars-inline-precompile@^0.2.3:
   version "0.2.3"
@@ -976,6 +997,13 @@ babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtim
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.3.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
@@ -1022,6 +1050,15 @@ babel-types@^6.10.2, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
+
+babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
 
 babel6-plugin-strip-class-callcheck@^6.0.0:
   version "6.0.0"
@@ -1360,6 +1397,24 @@ broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli
     broccoli-plugin "^1.3.0"
     debug "^2.2.0"
     exists-sync "0.0.4"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^0.5.3"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    mkdirp "^0.5.0"
+    path-posix "^1.0.0"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.3.1"
+
+broccoli-funnel@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz#6823c73b675ef78fffa7ab800f083e768b51d449"
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^1.3.0"
+    debug "^2.2.0"
     fast-ordered-set "^1.0.0"
     fs-tree-diff "^0.5.3"
     heimdalljs "^0.2.0"
@@ -2209,6 +2264,23 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-be
     clone "^2.0.0"
     ember-cli-version-checker "^2.0.0"
 
+ember-cli-babel@^6.3.0:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.0.1"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.0.0"
+
 ember-cli-babel@^6.6.0:
   version "6.8.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.1.tgz#695f94c57a9375c2a0e219306a41105d6b937991"
@@ -2640,6 +2712,10 @@ ember-resolver@^4.0.0:
 ember-rfc176-data@^0.2.0:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz#bd355bc9b473e08096b518784170a23388bc973b"
+
+ember-rfc176-data@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.0.tgz#6aee728cb521c5f80710990965027b9c320f6f08"
 
 ember-router-generator@^1.0.0:
   version "1.2.3"
@@ -4441,7 +4517,7 @@ lodash@^3.10.0, lodash@^3.10.1, lodash@^3.9.3:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -5219,6 +5295,10 @@ regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
 regenerator-runtime@^0.9.5:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
@@ -5922,7 +6002,7 @@ to-array@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
 
-to-fast-properties@^1.0.0, to-fast-properties@^1.0.1:
+to-fast-properties@^1.0.0, to-fast-properties@^1.0.1, to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 


### PR DESCRIPTION
This PR marks class fields as `attributes` in the validation meta object provided by `@ember-decorators/utils`.

## Why is this needed?

`ember-argument-decorators` by default provides validations on the arguments that are passed into a component. For instance, if you have a component like this:

```js
export default class ExampleComponent extends Component {

}
```

and try to use it like this:

```hbs
{{example-component foo="bar"}}
```

it will throw an error and tell you that the `foo` argument has not been defined. You must declare it as an argument like this:

```js
export default class ExampleComponent extends Component {
  @argument foo;
}
```

`@attribute` and `@className` can be applied to class fields as well, and currently the way they work clashes with the `@argument` decorator (they take the value provided by the field and assign it to the prototype, whereas the `@argument` decorator takes the value and assigns it in the constructor IFF a value has not already been assigned). Because of the difference in how they work, the two decorators cannot be made to work together. It's also undesirable from a DX standpoint - arguments and attributes have a clear distinction in Glimmer, so keeping that distinction in Ember is probably a good idea, even if they end up working similarly.

By adding information to the meta object that `ember-argument-decorators` uses, `ember-argument-decorators` can recognize that these fields exist and whitelist them, treating them similarly to arguments.

The meta information is stripped in production builds, so there won't be any perf implications for users who do not use `ember-argument-decorators`.

## Alternatives

`ember-argument-decorators` can re-export versions of `@attribute` and `@className` which are wrapped to store this meta information. This would likely be confusing for developers, but it can be addressed with thorough documentation.