### PR TITLE
deprecate(computed): Deprecate directly using @computed on functions

### DIFF
--- a/addon/object/index.js
+++ b/addon/object/index.js
@@ -72,64 +72,13 @@ export const action = decorator(function(target, key, desc) {
 });
 
 /**
- * Decorator that turns a function into a computed property.
- *
- * #### With Dependent Keys
- *
- * The values of the dependent properties are passed as arguments to the
- * function. You can also use
- * [property brace expansion](https://www.emberjs.com/blog/2014/02/12/ember-1-4-0-and-ember-1-5-0-beta-released.html#toc_property-brace-expansion).
- *
- * ```javascript
- * import EmberObject from '@ember/object';
- * import computed from 'ember-decorators/object';
- *
- * export default class User extends EmberObject {
- *   someKey = 'foo';
- *   otherKey = 'bar';
- *
- *   person = {
- *     firstName: 'John',
- *     lastName: 'Smith'
- *   };
- *
- *   @computed('someKey', 'otherKey')
- *   foo(someKey, otherKey) {
- *     return `${someKey} - ${otherKey}`; // => 'foo - bar'
- *   }
- *
- *   @computed('person.{firstName,lastName}')
- *   fullName(firstName, lastName) {
- *     return `${firstName} ${lastName}`; // => 'John Smith'
- *   }
- * }
- * ```
- *
- * #### Without Dependent Keys
- *
- * Computed properties without dependent keys are cached for the whole life span
- * of the object. You can only force a recomputation by calling
- * [`notifyPropertyChange`](https://www.emberjs.com/api/ember/2.14/classes/Ember.Observable/methods/notifyPropertyChange?anchor=notifyPropertyChange)
- * on the computed property.
- *
- * ```javascript
- * import EmberObject from '@ember/object';
- * import computed from 'ember-decorators/object';
- *
- * export default class FooBar extends EmberObject {
- *   @computed
- *   foo() {
- *     // calculate stuff
- *     return stuff;
- *   }
- * }
- * ```
- *
- * #### Getter and Setter
+ * Decorator that turns a function into a computed property. The decorators should
+ * be applied to native getter and setter functions. Note that though they use getters
+ * and setters, you must still use the Ember `get`/`set` functions to get and set their
+ * values.
  *
  * ```javascript
  * import Component from '@ember/component';
- * import { setProperties } from ''@ember/object';
  * import computed from 'ember-decorators/object';
  *
  * export default class UserProfileComponent extends Component {
@@ -137,22 +86,23 @@ export const action = decorator(function(target, key, desc) {
  *   last = 'Smith';
  *
  *   @computed('first', 'last')
- *   name = {
- *     get(first, last) {
- *       return `${first} ${last}`; // => 'John Smith'
- *     },
+ *   get name() {
+ *     const first = this.get('first');
+ *     const last = this.get('last');
  *
- *     set(value, first, last) {
- *       if (typeof value !== 'string' || !value.test(/^[a-z]+ [a-z]+$/i)) {
- *         throw new TypeError('Invalid name');
- *       }
+ *     return `${first} ${last}`; // => 'John Smith'
+ *   }
  *
- *       const [first, last] = value.split(' ');
- *       setProperties(this, { first, last });
- *
- *       return value;
+ *   set name(value) {
+ *     if (typeof value !== 'string' || !value.test(/^[a-z]+ [a-z]+$/i)) {
+ *       throw new TypeError('Invalid name');
  *     }
- *   };
+ *
+ *     const [first, last] = value.split(' ');
+ *     this.setProperties({ first, last });
+ *
+ *     return value;
+ *   }
  * }
  * ```
  *

--- a/addon/object/index.js
+++ b/addon/object/index.js
@@ -12,7 +12,7 @@ import {
 
 import { decoratorWithRequiredParams } from '../utils/decorator-macros';
 
-import { assert } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import {
   HAS_UNDERSCORE_ACTIONS,
   SUPPORTS_NEW_COMPUTED
@@ -206,6 +206,11 @@ export const computed = decoratorWithParams(function(target, key, desc, params) 
       return emberComputed(...params, callback);
     }
   } else {
+    deprecate(
+      'using @computed with functions directly will be removed in future versions, using ES getter/setter functions instead',
+      false,
+      { until: '2.0.0', id: 'macro-computed-deprecated' }
+    );
     return macroComputed(...params, extractValue(desc));
   }
 });


### PR DESCRIPTION
Adds a deprecation for macro-computeds and using `@computed` directly on functions. When `macro-helper-decorators` has been pulled out the deprecation can be updated to point toward it. 