### PR TITLE
bugfix(props): Normalizes property configurations by default 

### DIFF
--- a/addon/object/index.js
+++ b/addon/object/index.js
@@ -162,7 +162,7 @@ export const action = decorator(function(target, key, desc) {
 export const computed = decoratorWithParams(function(target, key, desc, params) {
   assert(`ES6 property getters/setters only need to be decorated once, '${key}' was decorated on both the getter and the setter`, !(desc.value instanceof Ember.ComputedProperty));
 
-  if (desc.writable === undefined) {
+  if ('get' in desc || 'set' in desc) {
     let { get, set } = desc;
 
     assert(`Using @computed for only a setter does not make sense. Add a getter for '${key}' as well or remove the @computed decorator.`, typeof get === 'function');

--- a/addon/utils/decorator-macros.js
+++ b/addon/utils/decorator-macros.js
@@ -3,6 +3,7 @@ import { IS_EMBER_2 } from 'ember-compatibility-helpers';
 import { decoratorWithParams } from './decorator-wrappers';
 import extractValue from './extract-value';
 import collapseProto from './collapse-proto';
+import normalizeDescriptor from './normalize-descriptor';
 
 import { assert } from '@ember/debug';
 
@@ -72,10 +73,7 @@ export function decoratedPropertyWithEitherCallbackOrProperty(fn) {
 
 export function decoratedConcatenatedProperty(concatProperty) {
   return function(target, key, desc) {
-    // Make sure the descriptor is correctly defined, defaults to false
-    desc.writable = true;
-    desc.configurable = true;
-
+    normalizeDescriptor(desc);
     collapseProto(target);
 
     if (!target.hasOwnProperty(concatProperty)) {

--- a/addon/utils/decorator-wrappers.js
+++ b/addon/utils/decorator-wrappers.js
@@ -1,10 +1,13 @@
 import isDescriptor from './is-descriptor';
+import normalizeDescriptor from './normalize-descriptor';
 
 function handleDescriptor(target, key, desc, fn, params = []) {
+  normalizeDescriptor(desc);
+
   return {
     enumerable: desc.enumerable,
     configurable: desc.configurable,
-    writeable: desc.writeable,
+    writable: desc.writable,
     value: fn(target, key, desc, params)
   };
 }

--- a/addon/utils/normalize-descriptor.js
+++ b/addon/utils/normalize-descriptor.js
@@ -1,0 +1,22 @@
+/**
+ * Normalizes property descriptor values.
+ *
+ * By default, the current babel class fields transform does not provide
+ * `writable` or `configurable` property values on descriptors. Instead, it
+ * checks to see if a value or initializer exists on the descriptor and if
+ * so makes the property writable. This is an issue with class fields
+ * that do not provide a default value or provide a falsy default value,
+ * since the initializer will just be the value, and writable will then
+ * default to false.
+ *
+ * This function normalizes the descriptor, making it writable/configurable
+ * by default if it hasn't already been provided (by another decorator, for
+ * instance).
+ *
+ * @param {PropertyDescriptor} desc
+ */
+export default function normalizeDescriptor(desc) {
+  desc.writable = 'writable' in desc ? desc.writable : true;
+  desc.configurable = 'configurable' in desc ? desc.configurable : true;
+  desc.enumerable = 'enumerable' in desc ? desc.enumerable : true;
+}

--- a/tests/unit/inject-test.js
+++ b/tests/unit/inject-test.js
@@ -37,6 +37,36 @@ test('service decorator works with service name', function(assert) {
   assert.ok(baz.get('fooService') instanceof FooService, 'service injected correctly');
 });
 
+test('service decorator works with class syntax', function(assert) {
+  const FooService = Ember.Object.extend();
+
+  this.register('service:foo', FooService);
+
+  this.register('class:baz', class Baz extends Ember.Object {
+    @service foo
+  });
+
+  const baz = this.container.lookup('class:baz');
+
+  assert.ok(baz.get('foo') instanceof FooService, 'service injected correctly');
+});
+
+test('can set service field', function(assert) {
+  assert.expect(0);
+
+  const FooService = Ember.Object.extend();
+
+  this.register('service:foo', FooService);
+
+  this.register('class:baz', class Baz extends Ember.Object {
+    @service foo
+  });
+
+  const baz = this.container.lookup('class:baz');
+
+  baz.set('foo', FooService.create());
+});
+
 test('controller decorator works without controller name', function(assert) {
   const FooController = Ember.Controller.extend();
 
@@ -48,7 +78,7 @@ test('controller decorator works without controller name', function(assert) {
 
   const baz = this.container.lookup('class:baz');
 
-  assert.ok(baz.get('foo') instanceof FooController, 'service injected correctly');
+  assert.ok(baz.get('foo') instanceof FooController, 'controller injected correctly');
 });
 
 test('controller decorator works with controller name', function(assert) {
@@ -62,5 +92,35 @@ test('controller decorator works with controller name', function(assert) {
 
   const baz = this.container.lookup('class:baz');
 
-  assert.ok(baz.get('foo') instanceof FooController, 'service injected correctly');
+  assert.ok(baz.get('foo') instanceof FooController, 'controller injected correctly');
+});
+
+test('controller decorator works with class syntax', function(assert) {
+  const FooController = Ember.Controller.extend();
+
+  this.register('controller:foo', FooController);
+
+  this.register('class:baz', class Baz extends Ember.Controller {
+    @controller foo
+  });
+
+  const baz = this.container.lookup('class:baz');
+
+  assert.ok(baz.get('foo') instanceof FooController, 'controller injected correctly');
+});
+
+test('can set controller field', function(assert) {
+  assert.expect(0);
+
+  const FooController = Ember.Controller.extend();
+
+  this.register('controller:foo', FooController);
+
+  this.register('class:baz', class Baz extends Ember.Controller {
+    @controller foo
+  });
+
+  const baz = this.container.lookup('class:baz');
+
+  baz.set('foo', FooController.create());
 });


### PR DESCRIPTION
This fixes an issue in the babel transform for decorators which is a [longstanding bug](https://github.com/loganfsmyth/babel-plugin-transform-decorators-legacy/pull/14). When class fields are decorated, they do not provide `writable` or `configurable` values. Instead, `writable` is set by `_applyDecoratedDescriptor` like so:

```js
  if ('value' in desc || desc.initializer) {
    desc.writable = true;
  }

  desc = decorators.slice().reverse().reduce(function (desc, decorator) {
    return decorator(target, property, desc) || desc;
  }, desc);
```

The issue arises when we define a class field without an initializer, i.e.

```js
class Foo() {
  @service bar;
}
```

The initial value is set to `null`, which means the initializer is falsy, so the descriptor is not modified. By the time it gets to our decorators the descriptor's `writable` value is still unset, meaning that a class field which likely should be writable is not.

This specifically clashes with legacy injections, which can cause the container to inject a field twice. It has popped up in other cases as well, such as the `@className` and `@attribute` decorators. Considering that class methods are by default writable, it makes sense that fields should be too unless they are otherwise specified (via another decorator, for instance).