### PR TITLE
feat(className): adds ability to specify true/false class names using @className

### DIFF
--- a/addon/utils/decorator-macros.js
+++ b/addon/utils/decorator-macros.js
@@ -2,8 +2,6 @@ import { IS_EMBER_2 } from 'ember-compatibility-helpers';
 
 import { decoratorWithParams } from './decorator-wrappers';
 import extractValue from './extract-value';
-import collapseProto from './collapse-proto';
-import normalizeDescriptor from './normalize-descriptor';
 
 import { assert } from '@ember/debug';
 
@@ -69,24 +67,4 @@ export function decoratedPropertyWithEitherCallbackOrProperty(fn) {
 
     return fn(...params, value);
   });
-}
-
-export function decoratedConcatenatedProperty(concatProperty) {
-  return function(target, key, desc) {
-    normalizeDescriptor(desc);
-    collapseProto(target);
-
-    if (!target.hasOwnProperty(concatProperty)) {
-      let parentValue = target[concatProperty];
-      target[concatProperty] = Array.isArray(parentValue) ? parentValue.slice() : [];
-    }
-
-    target[concatProperty].push(key);
-
-    // Set the value on the prototype in the case of class fields
-    desc.value = extractValue(desc);
-    desc.initializer = undefined;
-
-    return desc;
-  }
 }

--- a/tests/unit/component/class-name-test.js
+++ b/tests/unit/component/class-name-test.js
@@ -29,6 +29,44 @@ test('decorator adds class to component', function(assert) {
   assert.ok(find('.bar'));
 });
 
+test('decorator applies true/false class names', function(assert) {
+  class FooComponent extends Ember.Component {
+    @className('is-foo') foo = true;
+    @className('', 'is-not-bar') bar = false;
+    @className('', 'inactive') active = true;
+    @className('is-baz') baz = false;
+  }
+
+  this.register('component:foo-component', FooComponent);
+  this.register('template:components/foo-component', hbs`Hello, world!`);
+
+  this.render(hbs`{{foo-component}}`);
+
+  assert.ok(find('.is-foo'));
+  assert.ok(find('.is-not-bar'));
+  assert.notOk(find('.inactive'));
+  assert.notOk(find('.is-baz'));
+});
+
+test('decorator throws on incorrect parameter usage', function(assert) {
+  assert.throws(() => {
+    class Foo extends Ember.Object {
+      @className('is-foo', 'is-bar', 'is-baz') foo = true;
+    }
+
+    Foo.create();
+  }, /The @className decorator may take up to two parameters/);
+
+  assert.throws(() => {
+    class Foo extends Ember.Object {
+      @className('is-foo', 123) foo = true;
+    }
+
+    Foo.create();
+  }, /The @className decorator may only receive strings as parameters/);
+});
+
+
 test('class names can be overriden', function(assert) {
   class FooComponent extends Ember.Component {
     @className foo = 'button';


### PR DESCRIPTION
`classNameBindings` provides the ability to specify a name if the value of the field is truthy or falsy:

```js
classNameBindings: ['active:is-active:is-inactive']
```

This PR adds the same ability as optional parameters provided to the decorator:

```js
@className('is-active', 'is-inactive') active;
```

Because of the difference in code between `@attribute` and `@className`, the macro for concatenated properties was removed.