### PR TITLE
bugfix(build): Fixes the case where the addon has been included more than once

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "ember-cli-babel": "^6.0.0",
     "ember-cli-version-checker": "^2.0.0",
-    "ember-compatibility-helpers": "^0.1.0",
+    "ember-compatibility-helpers": "^0.1.2",
     "ember-macro-helpers": "^0.16.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #173 

The included hook only runs once per instance of the addon in the dependency graph. The babel transforms we are adding, however, are meant to be added to each addon that includes this addon as a dependency, as well as the root app. Because each addon has it's own version of ember-cli-babel, we have to make sure it happens for each of them.

To do this, we use the `init` hook instead of the `included` hook, since it runs each time the addon is created. Unfortunately, the init hook does not have any way to access the root app - that is only provided in the included hook. So, we still need to use included for the case where this addon is being used in an actual app.

TODO: Tests. We've had enough edge-cases and failures caused by misunderstandings of Ember-CLI, I think we need to figure out some way to test various addon inclusion scenarios to prevent issues like this.