### PR TITLE
Remove bower install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ highly recommended that you read the documentation for that addon as well.
 * `git clone <repository-url>` this repository
 * `cd ember-decorators`
 * `npm install`
-* `bower install`
 
 ## Running
 


### PR DESCRIPTION
I think bower is no longer used in this addon. If so, please merge