### PR TITLE
bind action to target

### DIFF
--- a/addon/object/index.js
+++ b/addon/object/index.js
@@ -18,7 +18,10 @@ import {
   SUPPORTS_NEW_COMPUTED
 } from 'ember-compatibility-helpers';
 
-const { computed: emberComputed } = Ember;
+const { 
+  computed: emberComputed,
+  run: { bind }
+} = Ember;
 
 /**
  * Decorator that turns the target function into an Action
@@ -68,7 +71,7 @@ export const action = decorator(function(target, key, desc) {
     target.actions[key] = value;
   }
 
-  return value;
+  return bind(target, value);
 });
 
 /**

--- a/tests/unit/action-test.js
+++ b/tests/unit/action-test.js
@@ -26,9 +26,11 @@ test('action decorator works with standard Ember Object model', function(assert)
 
 
 test('action decorator works with ES6 class', function(assert) {
+  assert.expect(2);
   this.register('component:foo-bar', class FooComponent extends Ember.Component {
     @action
     foo() {
+      assert.ok(this instanceof FooComponent);
       assert.ok(true, 'called!');
     }
   });


### PR DESCRIPTION
When dealing with closure actions, I found a use case where the context of the function was undefined. 

I added a test that shows the context is FooComponent, but I need to write a test where it isn't (or maybe make a dummy application to reproduce)