### PR TITLE
bugfix(node): Fixes the node version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "loader.js": "^4.2.3"
   },
   "engines": {
-    "node": "4.5 || 6.* || >= 7.*"
+    "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
In the upgrade to Ember-CLI 2.17 we accidentally messed up the Node version pin. This PR updates the pin and sets the test suite to run against the minimum version of Node.