### PR TITLE
[bugfix] Do not use inherited descriptors

### DIFF
--- a/packages/-ember-decorators/tests/unit/object/computed-test.js
+++ b/packages/-ember-decorators/tests/unit/object/computed-test.js
@@ -200,6 +200,30 @@ module('javascript | @computed', function() {
     );
   });
 
+  test('can decorate the same property in multiple subclasses', function(assert) {
+    assert.expect(0);
+
+    class Foo {
+      @computed('bar')
+      get fullName() {}
+    }
+
+    class Bar extends Foo {
+      @computed('foo')
+      get fullName() {}
+    }
+
+    class Baz extends Foo {
+      @computed('bar')
+      get fullName() {}
+    }
+
+    // shouldn't cause any errors
+    new Foo();
+    new Bar();
+    new Baz();
+  });
+
   module('@readOnly', function() {
 
     test('it works', function(assert) {

--- a/packages/object/addon/index.js
+++ b/packages/object/addon/index.js
@@ -4,7 +4,7 @@ import collapseProto from '@ember-decorators/utils/collapse-proto';
 import { computed as emberComputed } from '@ember-decorators/utils/compatibility';
 import { computedDecorator, computedDecoratorWithParams } from '@ember-decorators/utils/computed';
 
-import { assert } from '@ember/debug';
+import { deprecate, assert } from '@ember/debug';
 import { HAS_UNDERSCORE_ACTIONS } from 'ember-compatibility-helpers';
 
 /**
@@ -145,6 +145,12 @@ export const computed = computedDecoratorWithParams((target, key, desc, params) 
 export const readOnly = computedDecorator((target, name, desc) => {
   assert(`Attempted to apply @readOnly to '${name}', but it was not a computed property. Note that @readOnly must come before computed decorators`, desc && desc.isDescriptor);
   assert(`Attempted to apply @readOnly to a computed property that didn't have a setter, which is unnecessary`, !desc._setter || !desc._setter.isMissingSetter);
+
+  deprecate(
+    `Used @readOnly decorator on ${name}. The @readOnly decorator (imported from '@ember-decorators/object) has been deprecated and will be removed in future releases. To make a computed property readOnly, remove its 'set' function`,
+    false,
+    { until: '3.0.0', id: 'ember-decorators-read-only-decorator' }
+  );
 
   return desc.readOnly();
 });

--- a/packages/utils/addon/-private/descriptor.js
+++ b/packages/utils/addon/-private/descriptor.js
@@ -31,8 +31,9 @@ export function computedDescriptorFor(obj, keyName) {
   if (HAS_NATIVE_COMPUTED_GETTERS) {
     let meta = Ember.meta(obj);
 
-    if (meta !== undefined) {
-      return meta.peekDescriptors(keyName);
+    if (meta !== undefined && typeof meta._descriptors === 'object') {
+      // TODO: Just return the standard descriptor
+      return meta._descriptors[keyName];
     }
   } else if (Object.hasOwnProperty.call(obj, keyName)) {
     let { value: possibleDesc, get: possibleCPGetter } = Object.getOwnPropertyDescriptor(obj, keyName);


### PR DESCRIPTION
Currently, computed property decorators receive the last CP descriptor that
was assigned to the property. This way, a decorator can build off the last
decorator. This functionality is only used by the @readOnly decorator, which
marks an existing computed property as read only. The decorator is not
particularly useful anymore since for most standard computed properties,
all you need to do is not add a setter, so rather than keeping this behavior
this PR deprecates it and marks it for removal.

In the meantime, we still need to get the descriptor for the exact class
we're decorating - otherwise, we may attempt to decorate the superclass
instead, which was the root cause of #214