### PR TITLE
Add main dependency to example

### DIFF
--- a/packages/-ember-decorators/tests/dummy/app/pods/docs/quickstart/template.md
+++ b/packages/-ember-decorators/tests/dummy/app/pods/docs/quickstart/template.md
@@ -12,6 +12,7 @@ This will add the package, and should also add several babel packages to your
 app. You should see the following added to you `package.json`:
 
 ```json
+"ember-decorators": "{{latest version}}",
 "@ember-decorators/babel-transforms": "{{latest version}}",
 "babel-eslint": "{{latest version}}",
 ```


### PR DESCRIPTION
The example here should be clear that it adds the main `ember-decorators` addon and not only the other two dependencies. 
