### PR TITLE
[feat] add @macro util for creating decorators from macros (#213)

### DIFF
--- a/packages/-ember-decorators/tests/unit/object/macro-test.js
+++ b/packages/-ember-decorators/tests/unit/object/macro-test.js
@@ -1,8 +1,9 @@
-import { get, set } from '@ember/object';
+import { get, set, computed } from '@ember/object';
 import { A as emberA } from '@ember/array';
 import { gte } from 'ember-compatibility-helpers';
 
 import {
+  macro,
   alias,
   and,
   bool,
@@ -41,6 +42,41 @@ import { module, test } from 'qunit';
 import hasEmberVersion from 'ember-test-helpers/has-ember-version';
 
 module('javascript | macros', function() {
+
+  test('@macro', function (assert) {
+    // computed macro that returns the provided arguments as an array
+    const passthroughMacro = (...args) => computed(() => args);
+
+    class Foo {
+      @macro(passthroughMacro) noArgs;
+      @macro(passthroughMacro)('a', 'b') argsOnDecorator;
+      @macro(passthroughMacro, 'a', 'b') argsOnMacro;
+      @macro(passthroughMacro, 'a', 'b')('c', 'd') argsOnBoth;
+    }
+
+    const obj = new Foo();
+
+    assert.deepEqual(
+      get(obj, 'noArgs'),
+      [],
+      'invocation without arguments: @myMacro prop;'
+    );
+    assert.deepEqual(
+      get(obj, 'argsOnDecorator'),
+      ['a', 'b'],
+      'invocation with arguments passed to decorator: @myMacro(a, b) prop;'
+    );
+    assert.deepEqual(
+      get(obj, 'argsOnMacro'),
+      ['a', 'b'],
+      'invocation with arguments on macro (partial application): const myMacro = macro(macroFn, a, b);'
+    );
+    assert.deepEqual(
+      get(obj, 'argsOnBoth'),
+      ['a', 'b', 'c', 'd'],
+      'invocation with arguments on both'
+    );
+  });
 
   test('@alias', function(assert) {
     class Foo {


### PR DESCRIPTION
Implements a utility function for creating decorators from computed property macros. Both styles as discussed in #213 have been implemented:

```js
let foo = macro(bar);

class Foo {
  @foo('a', 'b') baz;
  @macro(bar)('c', 'd') qux;
}
```

```js
let foo = macro(bar, 'a', 'b');

class Foo {
  @foo baz;
  @macro(bar, 'c', 'd') qux;
}
```

Closes #213.