### PR TITLE
[bugfix] Always collapse proto from constructor

### DIFF
--- a/packages/utils/addon/collapse-proto.js
+++ b/packages/utils/addon/collapse-proto.js
@@ -2,9 +2,7 @@ export default function collapseProto(target) {
   // We must collapse the superclass prototype to make sure that the `actions`
   // object will exist. Since collapsing doesn't generally happen until a class is
   // instantiated, we have to do it manually.
-  let superClass = Object.getPrototypeOf(target.constructor);
-
-  if (superClass.hasOwnProperty('proto') && typeof superClass.proto === 'function') {
-    superClass.proto();
+  if (typeof target.constructor.proto === 'function') {
+    target.constructor.proto();
   }
 }


### PR DESCRIPTION
Currently we check the super class to see if it has `proto` and call it,
but that changed with @krisselden's recent PRs. Now only the base class
actually has `proto`, and class that inherits does get the method.

I believe the original implementation was overly cautious, calling proto
on subclasses should be fine all the way back through much older
versions of Ember. Everything should get applied correctly, because the
proto method only ever operated on the class in the closure until now,
it didn't use `this` or any context.