### PR TITLE
Typo in /latest/docs/class-fields

### DIFF
--- a/packages/-ember-decorators/tests/dummy/app/pods/docs/class-fields/template.md
+++ b/packages/-ember-decorators/tests/dummy/app/pods/docs/class-fields/template.md
@@ -247,7 +247,7 @@ class EmberObject {
 ```
 
 This means that the properties passed to `.create()` end up getting assigned
-_before_ the constructors for for any subclasses run. This means that when we
+_before_ the constructors for any subclasses run. This means that when we
 define a class that extends from `EmberObject`, class fields that are defined on
 our class will _always_ overwrite properties passed to `.create()`:
 


### PR DESCRIPTION
Spotted a small typo while reading the docs ;-)