### PR TITLE
@layout decorator for components in /addon

### DIFF
--- a/packages/-ember-decorators/tests/unit/component/layout-test.js
+++ b/packages/-ember-decorators/tests/unit/component/layout-test.js
@@ -1,0 +1,81 @@
+import Component from '@ember/component';
+import { layout } from '@ember-decorators/component';
+
+import hbs from 'htmlbars-inline-precompile';
+import { moduleForComponent } from 'ember-qunit';
+import { test } from 'qunit';
+import { find } from 'ember-native-dom-helpers';
+
+moduleForComponent('javascript | @layout', { integration: true });
+
+test('decorator sets layout of component', function(assert) {
+  @layout(hbs`<section class='foo'>Hello, world!</section>`)
+  class FooComponent extends Component {}
+
+  this.register('component:foo-component', FooComponent);
+
+  this.render(hbs`{{foo-component}}`);
+  assert.ok(find('section.foo'));
+});
+
+test('decorator throws an error if given a non-template value', function(assert) {
+  assert.throws(
+    () => {
+      @layout([`{{foo-component}}`])
+      class FooComponent extends Component {}
+
+      new FooComponent();
+    },
+    /The @layout decorator must be provided a template/,
+    'error thrown correctly'
+  )
+});
+test('decorator throws a specialized error if given a string value', function(assert) {
+  assert.throws(
+    () => {
+      @layout(`{{foo-component}}`)
+      class FooComponent extends Component {}
+
+      new FooComponent();
+    },
+    /use 'htmlbars-inline-precompile'/,
+    'error thrown correctly'
+  )
+});
+
+test('decorator throws an error if given more than one value', function(assert) {
+  assert.throws(
+    () => {
+      @layout('foo', 'bar')
+      class FooComponent extends Component {}
+
+      new FooComponent();
+    },
+    /The @layout decorator must be provided exactly one argument/,
+    'error thrown correctly'
+  )
+});
+
+test('decorator throws an error if given no values', function(assert) {
+  assert.throws(
+    () => {
+      @layout
+      class FooComponent extends Component {}
+
+      new FooComponent();
+    },
+    /The @layout decorator must be provided a template/, // Fails the string test because the class is passed in directly
+    'error thrown correctly'
+  )
+
+  assert.throws(
+    () => {
+      @layout()
+      class FooComponent extends Component {}
+
+      new FooComponent();
+    },
+    /The @layout decorator must be provided exactly one argument/,
+    'error thrown correctly'
+  )
+});

--- a/packages/component/addon/index.js
+++ b/packages/component/addon/index.js
@@ -153,3 +153,39 @@ export function tagName(tagName) {
     return klass;
   }
 }
+
+/**
+  Class decorator which specifies the layout for the component. This replaces
+  the `layout` property on components in the traditional Ember object model.
+
+  ```js
+  import template from '../templates/components/x-foo';
+
+  @layout(template)
+  export default class TagNameDemoComponent extends Component {}
+  ```
+
+  ```js
+  import hbs from 'htmlbars-inline-precompile';
+
+  @layout(hbs`<h1>Hello {{ name }}</h1>`)
+  export default class TagNameDemoComponent extends Component {
+    constructor() {
+      super(...arguments);
+      this.set('name', 'Tomster');
+    }
+  }
+  ```
+
+  @param {TemplateFactory} template - The compiled template to be used for the component
+*/
+export function layout(template) {
+  assert(`The @layout decorator must be provided exactly one argument, received: ${template}`, arguments.length === 1);
+  assert(`The @layout decorator must be provided a template, received: ${template}. If you want to compile strings to templates, be sure to use 'htmlbars-inline-precompile'`, typeof template !== 'string');
+  assert(`The @layout decorator must be provided a template, received: ${template}`, (() => typeof template === 'object' && typeof template.indexOf === 'undefined')());
+
+  return function(klass) {
+    klass.prototype.layout = template;
+    return klass;
+  }
+}


### PR DESCRIPTION
When generating a component in an addon, it's currently required to explicitly specify the layout since it won't automatically be resolved while living in the `/addon` folder

##### (A) ES5 - `ember g component x-foo --in-repo=my-addon`
```js
import Component from '@ember/component';
import layout from '../templates/components/x-foo';

export default Component.extend({
  layout
});
```
As people start to use ES6/TS, they're tempted to incorrectly consider `Component.extend { }` to be equivalent to `class extends Component { }`. This leads to the following bad patterns

##### (B) ES6/TS - common mistake of placing the layout on each instance, instead of the prototype
```ts
import Component from '@ember/component';
import layout from '../templates/components/x-foo';

export default class extends Component {
  layout = layout;
}
// or
export default class extends Component {
  constructor() {
    super(...arguments);
    this.layout = layout;
  }
}
```
To maintain equivalence with *(A)* while using ES6 or TS, the following is required

##### (C) ES6/TS - The best we can do today, to create the equivalent of (A) with classes
```ts
import Component from '@ember/component';
import layout from '../templates/components/x-foo';

export default class Foo extends Component {}

Foo.prototype.layout = layout; // 🤮
```
This change adds a new `@layout` decorator. It accepts exactly one argument, which should be a compiled template (either imported or inline-precompiled).

##### (D) The `@layout` decorator
  ```js
  import template from '../templates/components/x-foo';

  @layout(template)
  export default class TagNameDemoComponent extends Component {}
  ```

  ```js
  import hbs from 'htmlbars-inline-precompile';

  @layout(hbs`<h1>Hello {{ name }}</h1>`)
  export default class TagNameDemoComponent extends Component {
    constructor() {
      super(...arguments);
      this.set('name', 'Tomster');
    }
  }
  ```
