### PR TITLE
Improve docs and types for @observes, @unobserves, @on, and @off

### DIFF
--- a/packages/object/addon/index.js
+++ b/packages/object/addon/index.js
@@ -129,10 +129,9 @@ export const computed = computedDecoratorWithParams((target, key, desc, params) 
   Triggers the target function when the dependent properties have changed
 
   ```javascript
-  import Component from '@ember/component';
   import { observes } from '@ember-decorators/object';
 
-  export default class extends Component {
+  class Foo {
     @observes('foo')
     bar() {
       //...
@@ -141,7 +140,7 @@ export const computed = computedDecoratorWithParams((target, key, desc, params) 
   ```
 
   @function
-  @param {...String} eventNames - Names of the events that trigger the function
+  @param {...String} propertyNames - Names of the properties that trigger the function
  */
 export const observes = decoratorWithRequiredParams((target, key, desc, params) => {
   assert('The @observes decorator must be applied to functions', desc && typeof desc.value === 'function');
@@ -164,13 +163,13 @@ export const observes = decoratorWithRequiredParams((target, key, desc, params) 
     }
   }
 
-  class Bar {
+  class Bar extends Foo {
     @unobserves('foo') bar;
   }
   ```
 
   @function
-  @param {...String} eventNames - Names of the events that trigger the function
+  @param {...String} propertyNames - Names of the properties that no longer trigger the function
  */
 export const unobserves = decoratorWithRequiredParams((target, key, desc, params) => {
   for (let path of params) {
@@ -222,7 +221,7 @@ export const on = decoratorWithRequiredParams((target, key, desc, params) => {
   ```
 
   @function
-  @param {...String} eventNames - Names of the events that trigger the function
+  @param {...String} eventNames - Names of the events that no longer trigger the function
  */
 export const off = decoratorWithRequiredParams((target, key, desc, params) => {
   for (let eventName of params) {

--- a/packages/object/index.d.ts
+++ b/packages/object/index.d.ts
@@ -69,6 +69,90 @@ export function computed(
 ): PropertyDescriptor;
 
 /**
+  Triggers the target function when the dependent properties have changed
+
+  ```javascript
+  import { observes } from '@ember-decorators/object';
+
+  class Foo {
+    @observes('foo')
+    bar() {
+      //...
+    }
+  }
+  ```
+
+  @function
+  @param {...String} propertyNames - Names of the properties that trigger the function
+ */
+export function observes(...propertyNames: string[]): MethodDecorator;
+
+/**
+  Removes observers from the target function.
+
+  ```javascript
+  import { observes, unobserves } from '@ember-decorators/object';
+
+  class Foo {
+    @observes('foo')
+    bar() {
+      //...
+    }
+  }
+
+  class Bar extends Foo {
+    @unobserves('foo') bar;
+  }
+  ```
+
+  @function
+  @param {...String} propertyNames - Names of the properties that no longer trigger the function
+ */
+export function unobserves(...propertyNames: string[]): PropertyDecorator;
+
+/**
+  Adds an event listener to the target function.
+
+  ```javascript
+  import { on } from '@ember-decorators/object';
+
+  class Foo {
+    @on('fooEvent', 'barEvent')
+    bar() {
+      //...
+    }
+  }
+  ```
+
+  @function
+  @param {...String} eventNames - Names of the events that trigger the function
+ */
+export function on(...eventNames: string[]): MethodDecorator;
+
+/**
+  Removes an event listener from the target function.
+
+  ```javascript
+  import { on, off } from '@ember-decorators/object';
+
+  class Foo {
+    @on('fooEvent', 'barEvent')
+    bar() {
+      //...
+    }
+  }
+
+  class Bar extends Foo {
+    @off('fooEvent', 'barEvent') bar;
+  }
+  ```
+
+  @function
+  @param {...String} eventNames - Names of the events that no longer trigger the function
+ */
+export function off(...eventNames: string[]): PropertyDecorator;
+
+/**
  * Decorator that modifies a computed property to be read only.
  *
  * Usage:


### PR DESCRIPTION
1. Documentation updates:

- Change `eventNames` to `propertyNames` for @observes and @unobserves
- Make documentation of the argument to @unobserves and @off  more explicit
- Add missing `extends Foo` to the code example for @unobserves
- Remove unnecessary `extends Component` and `export default` in the documentation for @observes to better match the rest of the documentation.

2. Add types for @observes, @unobserves, @on, and @off.