### PR TITLE
[BUGFIX] Removes deprecation setter

### DIFF
--- a/packages/object/addon/index.js
+++ b/packages/object/addon/index.js
@@ -6,7 +6,6 @@ import { computedDecorator, computedDecoratorWithParams } from '@ember-decorator
 import { decoratorWithRequiredParams } from '@ember-decorators/utils/decorator';
 
 import { deprecate, assert } from '@ember/debug';
-import { get as emberGet, set as emberSet, defineProperty } from '@ember/object';
 import { addListener, removeListener } from '@ember/object/events';
 import { addObserver, removeObserver } from '@ember/object/observers';
 import { HAS_UNDERSCORE_ACTIONS } from 'ember-compatibility-helpers';
@@ -116,22 +115,11 @@ export const computed = computedDecoratorWithParams((target, key, desc, params) 
       let ret = set.call(this, value);
       return typeof ret === 'undefined' ? get.call(this) : ret;
     };
-  } else if (DEBUG) {
-    setter = function(key, value) {
-      let message = `Attempted to set ${
+  } else if (DEBUG && THROW_ON_COMPUTED_OVERRIDE) {
+    setter = function(key) {
+      assert(`Attempted to set ${
         key
-      }, but it does not have a setter. Overriding a computed property without a setter has been deprecated.`;
-
-      if (THROW_ON_COMPUTED_OVERRIDE) {
-        assert(message, false);
-      } else {
-        deprecate(message, { until: '3.0.0', id: '@ember-decorators/computed-overridability' });
-
-        let cachedValue = emberGet(this, key);
-        defineProperty(this, key, null, cachedValue);
-        emberSet(this, key, value);
-        return value;
-      }
+      }, but it does not have a setter. Overriding a computed property without a setter has been deprecated.`, false);
     };
 
     // Set flag to assert on redundant @readOnly


### PR DESCRIPTION
The current deprecation setter will cause users who opt out of hard
setter failures to be unable to legitimately use `@readOnly`. The better
option here is to wait for the `readOnly` RFC to be merged upstream in
Ember.