### PR TITLE
[REFACTOR] Rename readOnly -> reads, reads/oneWay -> overridableReads

### DIFF
--- a/packages/-ember-decorators/tests/unit/object/macro-test.js
+++ b/packages/-ember-decorators/tests/unit/object/macro-test.js
@@ -26,10 +26,9 @@ import {
   none,
   not,
   notEmpty,
-  oneWay,
   or,
+  overridableReads,
   reads,
-  readOnly,
   setDiff,
   sort,
   sum,
@@ -484,23 +483,6 @@ module('javascript | macros', function() {
     assert.equal(get(obj, 'isNamesEmpty'), false);
   });
 
-  test('@oneWay', function(assert) {
-    class Foo {
-      constructor() {
-        this.names = 'Tom';
-        this.nick = 'Tomster';
-      }
-      @oneWay('nick') nickName;
-    }
-
-    let obj = new Foo();
-
-    assert.equal(get(obj, 'nickName'), 'Tomster');
-    set(obj, 'nickName', 'Honeybadger');
-    assert.equal(get(obj, 'nickName'), 'Honeybadger');
-    assert.equal(get(obj, 'nick'), 'Tomster');
-  });
-
   test('@or', function(assert) {
     class Foo {
       constructor() {
@@ -517,13 +499,13 @@ module('javascript | macros', function() {
     assert.equal(get(obj, 'orValue'), 'rad');
   });
 
-  test('@reads', function(assert) {
+  test('@overridableReads', function(assert) {
     class Foo {
       constructor() {
         this.names = 'Tom';
         this.nick = 'Tomster';
       }
-      @reads('nick') nickName;
+      @overridableReads('nick') nickName;
     }
 
     let obj = new Foo();
@@ -534,13 +516,13 @@ module('javascript | macros', function() {
     assert.equal(get(obj, 'nick'), 'Tomster');
   });
 
-  test('@readOnly', function(assert) {
+  test('@reads', function(assert) {
     class Foo {
       constructor() {
         this.names = 'Tom';
         this.nick = 'Tomster';
       }
-      @readOnly('nick') nickName;
+      @reads('nick') nickName;
     }
 
     let obj = new Foo();

--- a/packages/object/addon/computed.js
+++ b/packages/object/addon/computed.js
@@ -23,7 +23,6 @@ import {
   notEmpty as emberNotEmpty,
   oneWay as emberOneWay,
   or as emberOr,
-  reads as emberReads,
   readOnly as emberReadOnly,
   setDiff as emberSetDiff,
   sort as emberSort,
@@ -601,29 +600,6 @@ export const not = legacyMacro(emberNot);
 export const notEmpty = legacyMacro(emberNotEmpty);
 
 /**
-  Where `computed.alias` aliases `get` and `set`, and allows for bidirectional
-  data flow, `computed.oneWay` only provides an aliased `get`. The `set` will
-  not mutate the upstream property, rather causes the current property to
-  become the value set. This causes the downstream property to permanently
-  diverge from the upstream property.
-
-  Equivalent to the Ember [oneWay](https://emberjs.com/api/ember/3.1/functions/@ember%2Fobject%2Fcomputed/oneWay) macro.
-
-  ```js
-  export default class UserProfileComponent extends Component {
-    firstName = 'Joe';
-
-    @oneWay('firstName') originalName; // 'Joe'
-  }
-  ```
-
-  @function
-  @param {string} dependentKey - Key for the property to alias
-  @return {any}
-*/
-export const oneWay = legacyMacro(emberOneWay);
-
-/**
   A computed property which performs a logical or on the original values for the
   provided dependent properties.
 
@@ -645,10 +621,46 @@ export const oneWay = legacyMacro(emberOneWay);
 export const or = legacyMacro(emberOr);
 
 /**
-  This is a more semantically meaningful alias of `oneWay`, whose name is
-  somewhat ambiguous as to which direction the data flows.
+  Where `@alias` aliases `get` and `set`, and allows for bidirectional
+  data flow, `@overrideableReads` only provides an aliased `get`. Setting the
+  property removes the alias and causes it to be overridden entirely. This means
+  that the property will not update any longer once it has been set once, making
+  it a one way trap.
 
-  Equivalent to the Ember [reads](https://emberjs.com/api/ember/3.1/functions/@ember%2Fobject%2Fcomputed/reads) macro.
+  Equivalent to the Ember [oneWay](https://emberjs.com/api/ember/3.1/functions/@ember%2Fobject%2Fcomputed/oneWay)
+  and Ember [reads](https://emberjs.com/api/ember/3.1/functions/@ember%2Fobject%2Fcomputed/reads) macros
+
+  ```js
+  export default class UserProfileComponent extends Component {
+    firstName = 'Joe';
+
+    @overridableReads('firstName') originalName; // 'Joe'
+  }
+  ```
+
+  @function
+  @param {string} dependentKey - Key for the property to alias
+  @return {any}
+*/
+export const overridableReads = legacyMacro(emberOneWay);
+
+/**
+  A computed property which creates a one way read-only alias to the original
+  value for property. Where `@alias` aliases `get` and `set`, and
+  `@overridableReads` aliases get but can be overridden when set, `@reads`
+  provides a read only one way binding that will throw if a set is attempted.
+  Very often when using `@reads` one wants to explicitly prevent users from ever
+  setting the property. This prevents the reverse flow, and also throws an
+  exception when it occurs.
+
+  Equivalent to the Ember [readOnly](https://emberjs.com/api/ember/3.1/functions/@ember%2Fobject%2Fcomputed/readOnly) macro.
+
+  It is very important to note that this is ___not___ the same as
+  `Ember.computed.reads`, which creates an overridable one way alias. The reason
+  `ember-decorators` has chosen to change the name of this computed macro is to
+  avoid conflicting with the `@readOnly` decorator which is used to mark any
+  computed property as read-only. For an equivalent to `Ember.computed.reads`,
+  see `@overridableReads`.
 
   ```js
   export default class UserProfileComponent extends Component {
@@ -662,30 +674,7 @@ export const or = legacyMacro(emberOr);
   @param {string} dependentKey - Key for the property to read
   @return {any}
 */
-export const reads = legacyMacro(emberReads);
-
-/**
-  A computed property which creates a one way computed property to the original
-  value for property. Where `@reads` provides a one way bindings, `@readOnly`
-  provides a read only one way binding. Very often when using `@reads` one wants
-  to explicitly prevent users from ever setting the property. This prevents the
-  reverse flow, and also throws an exception when it occurs.
-
-  Equivalent to the Ember [readOnly](https://emberjs.com/api/ember/3.1/functions/@ember%2Fobject%2Fcomputed/readOnly) macro.
-
-  ```js
-  export default class UserProfileComponent extends Component {
-    first = 'Tomster';
-
-    @readOnly('first') firstName;
-  }
-  ```
-
-  @function
-  @param {string} dependentKey - Key for the property to read
-  @return {any}
-*/
-export const readOnly = legacyMacro(emberReadOnly);
+export const reads = legacyMacro(emberReadOnly);
 
 /**
   A computed property which returns a new array with all the properties from the


### PR DESCRIPTION
The unfortunate naming conflict between the two different kinds of
`@readOnly` decorators is very confusing and makes it difficult to tell
what is going on without context. Now that overridability has been
deprecated, the naming makes even less sense.

This PR renames the `@readOnly` decorator to `@reads`, since it will
represent the default behavior in the new world (non-overridable one
directional alias). It also renames `@oneWay` to be `@overridableReads`
for clarity. This macro will likely continue to exist even in the
post-`readOnly` world, and continue to have the same functionality it
has now, so it makes sense to name it appropriately.