### PR TITLE
[REFACTOR] Change shouldThrowOnComputedOverride to false by default

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -71,7 +71,7 @@ module.exports = function() {
         {
           name: 'throw-on-computed-override',
           env: {
-            EMBER_DECORATORS_THROW_ON_COMPUTED_OVERRIDE: false,
+            EMBER_DECORATORS_THROW_ON_COMPUTED_OVERRIDE: true,
           },
           npm: {
             devDependencies: {}

--- a/packages/-ember-decorators/tests/unit/object/computed-test.js
+++ b/packages/-ember-decorators/tests/unit/object/computed-test.js
@@ -339,7 +339,7 @@ module('javascript | @computed', function() {
 
           assert.throws(() => {
             set(obj, 'name', 'al');
-          }, /Cannot set read-only property "name" on object: {first: rob, last: jackson}/);
+          }, /Cannot set read-only property "name" on object:/);
         });
 
         test('readOnly can be applied in any order', function(assert) {
@@ -358,7 +358,7 @@ module('javascript | @computed', function() {
 
           assert.throws(() => {
             set(obj, 'name', 'al');
-          }, /Cannot set read-only property "name" on object: {first: rob, last: jackson}/);
+          }, /Cannot set read-only property "name" on object:/);
         });
 
         test('volatile and readOnly cannot be applied together', (assert) => {

--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -11,7 +11,7 @@ function setupBabelPlugins(addon, options) {
   } else {
     shouldThrowOnComputedOverride = options && 'throwOnComputedOverride' in options
         ? options.throwOnComputedOverride
-        : true;
+        : false;
   }
 
   let pluginOptions = {


### PR DESCRIPTION
Changes the default value of `shouldThrowOnComputedOverride` to false in
order to facilitate codemodding. We're doing this to match the existing
behavior of computed properties as closely as possible, so that
codemodding existing classes is as safe as possible.