### PR TITLE
[v3] update @types/ember, @types/ember-data

### DIFF
--- a/packages/-ember-decorators/package.json
+++ b/packages/-ember-decorators/package.json
@@ -33,8 +33,8 @@
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^2.0.1",
     "@ember-decorators/utils": "^3.0.0-beta.0",
-    "@types/ember": "^2.8.22",
-    "@types/ember-data": "^2.14.17",
+    "@types/ember": "^3.0.0",
+    "@types/ember-data": "^3.1.0",
     "@types/ember-qunit": "^3.0.2",
     "@types/ember-test-helpers": "^0.7.1",
     "@types/ember-testing-helpers": "0.0.3",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^2.0.0",
     "@ember-decorators/object": "^3.0.0-beta.0",
-    "@types/ember": "^2.8.31",
-    "@types/ember-data": "^2.14.9",
+    "@types/ember": "^3.0.0",
+    "@types/ember-data": "^3.1.0",
     "@types/ember-test-helpers": "^0.7.1",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -26,8 +26,8 @@
   },
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^2.0.0",
-    "@types/ember": "^2.8.12",
-    "@types/ember-data": "^2.14.9",
+    "@types/ember": "^3.0.0",
+    "@types/ember-data": "^3.1.0",
     "@types/ember-test-helpers": "^0.7.1",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",

--- a/packages/data/index.d.ts
+++ b/packages/data/index.d.ts
@@ -1,4 +1,6 @@
-import DS, { ModelRegistry, TransformRegistry } from "ember-data";
+import DS from "ember-data";
+import TransformRegistry from "ember-data/types/registries/transform";
+import ModelRegistry from "ember-data/types/registries/model";
 
 /**
  * Decorator that turns the property into an Ember Data attribute

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -26,8 +26,8 @@
   },
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^2.0.0",
-    "@types/ember": "^2.8.12",
-    "@types/ember-data": "^2.14.17",
+    "@types/ember": "^3.0.0",
+    "@types/ember-data": "^3.1.0",
     "@types/ember-test-helpers": "^0.7.1",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",

--- a/packages/object/package.json
+++ b/packages/object/package.json
@@ -27,8 +27,8 @@
   },
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^2.0.0",
-    "@types/ember": "^2.8.12",
-    "@types/ember-data": "^2.14.9",
+    "@types/ember": "^3.0.0",
+    "@types/ember-data": "^3.1.0",
     "@types/ember-test-helpers": "^0.7.1",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -26,8 +26,8 @@
   },
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^2.0.0",
-    "@types/ember": "^2.8.12",
-    "@types/ember-data": "^2.14.9",
+    "@types/ember": "^3.0.0",
+    "@types/ember-data": "^3.1.0",
     "@types/ember-test-helpers": "^0.7.1",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,8 +27,8 @@
   },
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^2.0.0",
-    "@types/ember": "^2.8.9",
-    "@types/ember-data": "^2.14.8",
+    "@types/ember": "^3.0.0",
+    "@types/ember-data": "^3.1.0",
     "@types/ember-test-helpers": "^0.7.0",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",


### PR DESCRIPTION
Fixes https://github.com/typed-ember/ember-cli-typescript/issues/329

This PR allows ember-decorators to work with the latest release of the ember and ember-data type information.

This is for the ember-decorators@^3 release stream. The equivalent for the ^2 stream is #286