### PR TITLE
fix(utils): only setup babel once

### DIFF
--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -1,4 +1,9 @@
+const didSetup = new Set;
+
 function setupBabelPlugins(addon, options) {
+  if (didSetup.has(addon)) return;
+  didSetup.add(addon);
+
   addon.options = addon.options || {};
   addon.options.babel = addon.options.babel || {};
 
@@ -40,7 +45,11 @@ function setupBabelPlugins(addon, options) {
     },
   };
 
-  plugins.push([require.resolve('babel-plugin-debug-macros'), pluginOptions]);
+  plugins.push([
+    require.resolve('babel-plugin-debug-macros'),
+    pluginOptions,
+    'ember-decorators-debug-macros'
+  ]);
 }
 
 module.exports = {


### PR DESCRIPTION
I don't know, if the actual setup matters, because I did not create a reproduction repo yet, but it is quite convoluted. Basically it goes like this, all in one big monorepo:

```
host-app
+- lazy-loaded-engine
   +- some-addon
      +- @ember-decorators/utils
```
<details>
  <summary>Outdated, incorrect mumbling</summary>

~Somehow, if _and only if_ `some-addon` specifies non-`js` file extensions for `ember-cli-babel`, like shown below, it causes `@ember-decorators/utils` to be `included` multiple times into (presumably) `some-addon`.~

```js
// some-addon/index.js

module.exports = {
  name: '@clark/ember-native',

  options: {
    // as soon as this config key is present, things go wrong
    'ember-cli-babel': {
      extensions: ['js', 'ts'] // 'js' only causes no error
    }
  }
};
```
</details>

See https://github.com/ember-decorators/ember-decorators/pull/290#issuecomment-431169146 for updated information.

The following error is then thrown:

```
Build Error (broccoli-persistent-filter:Babel > [Babel: @clark/ember-native]) in @clark/ember-native/bridges/android.ts

Duplicate plugin/preset detected.
If you'd like to use two separate instances of a plugin,
they need separate names, e.g.

  plugins: [
    ['some-plugin', {}],
    ['some-plugin', {}, 'some unique name'],
  ]
    at assertNoDuplicates (/Users/janbuschtoens/clark/application/node_modules/@babel/core/lib/config/config-descriptors.js:206:13)
    at createDescriptors (/Users/janbuschtoens/clark/application/node_modules/@babel/core/lib/config/config-descriptors.js:114:3)
    at createPluginDescriptors (/Users/janbuschtoens/clark/application/node_modules/@babel/core/lib/config/config-descriptors.js:105:10)
    at alias (/Users/janbuschtoens/clark/application/node_modules/@babel/core/lib/config/config-descriptors.js:63:49)
    at cachedFunction (/Users/janbuschtoens/clark/application/node_modules/@babel/core/lib/config/caching.js:33:19)
    at plugins.plugins (/Users/janbuschtoens/clark/application/node_modules/@babel/core/lib/config/config-descriptors.js:28:77)
    at mergeChainOpts (/Users/janbuschtoens/clark/application/node_modules/@babel/core/lib/config/config-chain.js:314:26)
    at /Users/janbuschtoens/clark/application/node_modules/@babel/core/lib/config/config-chain.js:278:7
    at buildRootChain (/Users/janbuschtoens/clark/application/node_modules/@babel/core/lib/config/config-chain.js:68:29)
    at loadPrivatePartialConfig (/Users/janbuschtoens/clark/application/node_modules/@babel/core/lib/config/partial.js:85:55)
```

Some investigation has shown that this is caused by the following line being executed more than once for the including addon.

https://github.com/ember-decorators/ember-decorators/blob/d804943a8bd9bf079b532a12c2c4ae51aca6235c/packages/utils/index.js#L43

This PR ensures that `setupBabelPlugins(addon, options)` is only ever run once for any given `addon`.

Seeing that this only happens, if non-`js` file extensions are provided, this might not actually be the correct place to fix, but it works. I'll also raise an issue over at `ember-cli-babel`.

/cc @dfreeman @pzuraq @rwjblue