### PR TITLE
fix(utils): only install debug-macros plugin once

### DIFF
--- a/packages/utils/index.js
+++ b/packages/utils/index.js
@@ -1,13 +1,13 @@
-const didSetup = new Set;
+const PLUGIN_NAME = 'ember-decorators-debug-macros';
 
 function setupBabelPlugins(addon, options) {
-  if (didSetup.has(addon)) return;
-  didSetup.add(addon);
-
   addon.options = addon.options || {};
   addon.options.babel = addon.options.babel || {};
 
   let plugins = addon.options.babel.plugins = addon.options.babel.plugins || [];
+
+  // If the plugin is already configure, skip.
+  if (plugins.some(p => Array.isArray(p) && p[2] === PLUGIN_NAME)) return;
 
   let shouldThrowOnComputedOverride
 
@@ -48,7 +48,7 @@ function setupBabelPlugins(addon, options) {
   plugins.push([
     require.resolve('babel-plugin-debug-macros'),
     pluginOptions,
-    'ember-decorators-debug-macros'
+    PLUGIN_NAME
   ]);
 }
 


### PR DESCRIPTION
https://github.com/ember-decorators/ember-decorators/pull/290#issuecomment-431366393

> Seems like my solution was too naïve. I have now added `some-addon` as a dependency to `host-app` as well (in addition to `lazy-loaded-engine`):
> 
> ```
> host-app
> +- lazy-loaded-engine
> |  +- some-addon
> |     +- @ember-decorators/utils
> +- some-addon
>    +- @ember-decorators/utils
> ```
> And now I get the same errors again. 😂
> 
> I'll submit a PR that actually checks that the specific plugin is not already in the plugins list.

Sorry for the back and forth. Should have probably implemented it like this in the first place anyway, but my brain was fried last night. 😵 