### PR TITLE
docs(computed): fix sortDefinition documentation

### DIFF
--- a/packages/object/addon/computed.js
+++ b/packages/object/addon/computed.js
@@ -733,6 +733,14 @@ export const setDiff = legacyMacro(emberSetDiff);
   export default class SortNamesComponent extends Component {
     names = [{name:'Link'},{name:'Zelda'},{name:'Ganon'},{name:'Navi'}];
 
+    // sortDefinition syntax:
+
+    sorts = Object.freeze(['name:asc']);
+    @sort('names', 'sorts')
+    sortedNames; // [{name:'Ganon'},{name:'Link'},{name:'Navi'},{name:'Zelda'}]
+
+    // sort function syntax:
+
     @sort('names')
     sortedNames(a, b){
       if (a.name > b.name) {
@@ -762,7 +770,7 @@ export const setDiff = legacyMacro(emberSetDiff);
 
   @function
   @param {string} dependentKey - The key for the array that should be sorted
-  @param {string[] | (itemA: any, itemB: any) => number} sortDefinition? - Sorting function or sort descriptor
+  @param {string | (itemA: any, itemB: any) => number} sortDefinition? - Sorting function or sort descriptor
   @return {any[]}
 */
 export const sort = legacyMacro(emberSort);

--- a/packages/object/computed.d.ts
+++ b/packages/object/computed.d.ts
@@ -729,6 +729,14 @@ export function setDiff(
  * export default class SortNamesComponent extends Component {
  *   names = A([{name:'Link'},{name:'Zelda'},{name:'Ganon'},{name:'Navi'}]);
  *
+ *   // sortDefinition syntax:
+ *
+ *   sorts = Object.freeze(['name:asc']);
+ *   @sort('names', 'sorts')
+ *   sortedNames; // [{name:'Ganon'},{name:'Link'},{name:'Navi'},{name:'Zelda'}]
+ *
+ *   // sort function syntax:
+ *
  *   @sort('names')
  *   sortedNames(a, b){
  *     if (a.name > b.name) {
@@ -756,7 +764,7 @@ export function setDiff(
  *
  * @function
  * @param {String} dependentKey - The key for the array that should be sorted
- * @param {Array<String>|Function(Any, Any): Number} sortDefinition - Sorting function or sort descriptor
+ * @param {String|Function(Any, Any): Number} sortDefinition - Sorting function or sort descriptor
  */
 export function sort<T>(
   dependentKey: string,


### PR DESCRIPTION
Previously the jsdoc defined sortDefinition as possible string array. 
This is incorrect as tests check for usage as a string and [ember docs](https://emberjs.com/api/ember/3.5/functions/@ember%2Fobject%2Fcomputed/sort) describe the string sortDefinition to be a simple string.