### PR TITLE
fix(utils/decorator): transfer initializer, detect synthetic descriptors

### DIFF
--- a/packages/utils/addon/decorator.js
+++ b/packages/utils/addon/decorator.js
@@ -103,6 +103,13 @@ export function decorator(fn) {
           desc.finisher(target.prototype ? target : target.constructor);
         }
 
+        if (desc.initializer) {
+          // We've removed the initializer in `convertStage1ToStage2` to mirror
+          // the specs for field descriptor, but Babel 6 needs the initializer
+          // back on the property descriptor.
+          desc.descriptor.initializer = desc.initializer;
+        }
+
         return desc.descriptor;
       }
     }

--- a/packages/utils/addon/decorator.js
+++ b/packages/utils/addon/decorator.js
@@ -61,11 +61,16 @@ function convertStage1ToStage2(desc) {
     let kind = kindForDesc(desc);
     let placement = placementForKind(kind);
 
+    let { initializer } = descriptor;
+    delete descriptor.initializer;
+
     return {
       descriptor,
       key,
       kind,
       placement,
+      initializer,
+      toString: () => '[object Descriptor]',
     };
   } else {
     // Class decorator

--- a/packages/utils/addon/decorator.js
+++ b/packages/utils/addon/decorator.js
@@ -62,7 +62,6 @@ function convertStage1ToStage2(desc) {
     let placement = placementForKind(kind);
 
     let { initializer } = descriptor;
-    delete descriptor.initializer;
 
     return {
       descriptor,
@@ -93,7 +92,7 @@ export function decorator(fn) {
 
         fn(desc);
 
-        if (desc.finisher) {
+        if (typeof desc.finisher === 'function') {
           // Finishers are supposed to run at the end of class finalization,
           // but we don't get that with stage 1 transforms. We have to be careful
           // to make sure that we aren't doing any operations which would change
@@ -103,10 +102,11 @@ export function decorator(fn) {
           desc.finisher(target.prototype ? target : target.constructor);
         }
 
-        if (desc.initializer) {
-          // We've removed the initializer in `convertStage1ToStage2` to mirror
-          // the specs for field descriptor, but Babel 6 needs the initializer
-          // back on the property descriptor.
+        if (typeof desc.initializer === 'function') {
+          // Babel 6 / the legacy decorator transform needs the initializer back
+          // on the property descriptor/ In case the user has set a new
+          // initializer on the member descriptor, we transfer it back to
+          // original descriptor.
           desc.descriptor.initializer = desc.initializer;
         }
 


### PR DESCRIPTION
If we are dealing with legacy decorators and a decorated member has an `initializer`, the `initializer` is kept on the property descriptor and not transferred to the synthetic member descriptor. This PR deletes the `initializer` from the original descriptor and transfers it.

dd9348a0dca4e43af157d645f202bc92db544ce8 then transfers the initializer back to the property descriptor, just before we give it back to Babel.

Relevant part of the spec: [Field Decorator > Parameters](https://github.com/tc39/proposal-decorators/blob/master/METAPROGRAMMING.md#parameters)

This PR also adds a `toString` method to the synthetic member descriptor, so that `isStage2Descriptor` detects synthetic member descriptors as such to enable the pattern shown in https://github.com/ember-decorators/ember-decorators/issues/315#issuecomment-441720711 for legacy decorators as well.