### PR TITLE
[data] Support types for ES6 Model subclass w/ @attr

### DIFF
--- a/packages/data/index.d.ts
+++ b/packages/data/index.d.ts
@@ -16,7 +16,7 @@ import ModelRegistry from "ember-data/types/registries/model";
  *
  * @function
  */
-export function attr(): PropertyDecorator;
+export function attr(target: Object, propertyKey: string | symbol): void;
 /**
  * Decorator that turns the property into an Ember Data attribute
  *


### PR DESCRIPTION
#### Test Case

```ts
import Model from 'ember-data/model';
import { attr } from '@ember-decorators/data';

/// 🚨 This case will fail with current types 🚨///
class MyModel1 extends Model {
  @attr firstName: null 
}

class MyModel2 extends Model {
  @attr('string') firstName: null
}

class MyModel3 extends Model {
  @attr('string', { allowNull: false }) firstName: null
}

class MyModel4 extends Model {
  @attr() firstName: null
}
```

Currently all forms of the types for `attr` are functions that return decorators. This PR adds the form that uses `@attr` directly