### PR TITLE
[BUGFIX] Fixes version cleaning logic when checking for TS

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -25,7 +25,6 @@
     "ember-cli-babel": "^7.1.3",
     "ember-cli-version-checker": "^2.1.2",
     "ember-compatibility-helpers": "^1.1.2",
-    "fs-extra": "^7.0.1",
     "semver": "^5.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Ensures that we check as many possibilities as possible for TS versions in an addon, and that we guard against possibly unreadable versions (such as `*` in in-repo addon packages)