### PR TITLE
fix(utils/decorator): handle desc return value

### DIFF
--- a/packages/-ember-decorators/package.json
+++ b/packages/-ember-decorators/package.json
@@ -68,6 +68,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-native-dom-helpers": "^0.5.0",
+    "ember-qunit-assert-helpers": "^0.2.1",
     "ember-resolver": "^4.0.0",
     "ember-root-url": "^0.2.0",
     "ember-source": "~3.0.0",

--- a/packages/-ember-decorators/tests/unit/utils/decorator-helpers-test.js
+++ b/packages/-ember-decorators/tests/unit/utils/decorator-helpers-test.js
@@ -1,12 +1,55 @@
 import { DEBUG } from '@glimmer/env';
 
 import { module, test } from 'qunit';
-import { decoratorWithParams, decoratorWithRequiredParams } from '@ember-decorators/utils/decorator';
+import {
+  decorator,
+  decoratorWithParams,
+  decoratorWithRequiredParams,
+} from '@ember-decorators/utils/decorator';
 
 module('decorator helpers', function() {
+  module('decorator', function() {
+    test('it works with returning a newly created member descriptor', function(assert) {
+      let decorate = decorator(desc => {
+        return {
+          ...desc,
+          descriptor: {
+            configurable: desc.configurable,
+            enumerable: desc.enumerable,
+            get() {
+              return 1337;
+            },
+          },
+        };
+      });
+
+      class Foo {
+        @decorate foo() {}
+      }
+
+      let foo = new Foo();
+      assert.strictEqual(foo.foo, 1337);
+    });
+
+    test('it warns about deprecated descriptor mutation by reference', function(assert) {
+      let decorate = decorator(desc => {
+        delete desc.descriptor.value;
+        delete desc.descriptor.writable;
+        desc.descriptor.get = () => 1337;
+      });
+
+      assert.expectDeprecation(() => {
+        class Foo {
+          @decorate foo() {}
+        }
+
+        let foo = new Foo();
+        assert.strictEqual(foo.foo, 1337);
+      }, /Directly mutating the descriptor by reference is deprecated. Return it instead./);
+    });
+  });
 
   module('decoratorWithParams', function() {
-
     test('it works with params', function(assert) {
       let decorate = decoratorWithParams(({ key }, params) => {
         assert.equal(key, 'foo', 'correct key decorated');
@@ -48,32 +91,9 @@ module('decorator helpers', function() {
 
       new Foo();
     });
-
-    test('it works with returning a newly created member descriptor', function(assert) {
-      let decorate = decoratorWithParams(desc => {
-        return {
-          ...desc,
-          descriptor: {
-            configurable: desc.configurable,
-            enumerable: desc.enumerable,
-            get() {
-              return 1337;
-            }
-          }
-        }
-      });
-
-      class Foo {
-        @decorate() foo() {}
-      }
-
-      let foo = new Foo();
-      assert.strictEqual(foo.foo, 1337);
-    });
   });
 
   module('decoratorWithRequiredParams', function() {
-
     test('it works with params', function(assert) {
       let decorate = decoratorWithRequiredParams(({ key }, params) => {
         assert.equal(key, 'foo', 'correct key decorated');
@@ -91,37 +111,31 @@ module('decorator helpers', function() {
 
     if (DEBUG) {
       test('it throws without params', function(assert) {
-        assert.throws(
-          () => {
-            let decorate = decoratorWithRequiredParams(() => {
-              assert.ok(false, 'decorator ran');
-            }, 'decorate');
+        assert.throws(() => {
+          let decorate = decoratorWithRequiredParams(() => {
+            assert.ok(false, 'decorator ran');
+          }, 'decorate');
 
-            class Foo {
-              @decorate foo() {}
-            }
+          class Foo {
+            @decorate foo() {}
+          }
 
-            new Foo();
-          },
-          /The @decorate decorator requires parameters/
-        );
+          new Foo();
+        }, /The @decorate decorator requires parameters/);
       });
 
       test('it throws with empty params list', function(assert) {
-        assert.throws(
-          () => {
-            let decorate = decoratorWithRequiredParams(() => {
-              assert.ok(false, 'decorator ran');
-            }, 'decorate');
+        assert.throws(() => {
+          let decorate = decoratorWithRequiredParams(() => {
+            assert.ok(false, 'decorator ran');
+          }, 'decorate');
 
-            class Foo {
-              @decorate() foo() {}
-            }
+          class Foo {
+            @decorate() foo() {}
+          }
 
-            new Foo();
-          },
-          /The @decorate decorator requires parameters/
-        );
+          new Foo();
+        }, /The @decorate decorator requires parameters/);
       });
     }
   });

--- a/packages/-ember-decorators/tests/unit/utils/decorator-helpers-test.js
+++ b/packages/-ember-decorators/tests/unit/utils/decorator-helpers-test.js
@@ -48,6 +48,28 @@ module('decorator helpers', function() {
 
       new Foo();
     });
+
+    test('it works with returning a newly created member descriptor', function(assert) {
+      let decorate = decoratorWithParams(desc => {
+        return {
+          ...desc,
+          descriptor: {
+            configurable: desc.configurable,
+            enumerable: desc.enumerable,
+            get() {
+              return 1337;
+            }
+          }
+        }
+      });
+
+      class Foo {
+        @decorate() foo() {}
+      }
+
+      let foo = new Foo();
+      assert.strictEqual(foo.foo, 1337);
+    });
   });
 
   module('decoratorWithRequiredParams', function() {

--- a/packages/-ember-decorators/tests/unit/utils/decorator-helpers-test.js
+++ b/packages/-ember-decorators/tests/unit/utils/decorator-helpers-test.js
@@ -1,6 +1,7 @@
 import { DEBUG } from '@glimmer/env';
+import { NEEDS_STAGE_1_DECORATORS } from 'ember-decorators-flags';
 
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import {
   decorator,
   decoratorWithParams,
@@ -31,7 +32,9 @@ module('decorator helpers', function() {
       assert.strictEqual(foo.foo, 1337);
     });
 
-    test('it warns about deprecated descriptor mutation by reference', function(assert) {
+    (NEEDS_STAGE_1_DECORATORS
+      ? test
+      : skip)('it warns about deprecated descriptor mutation by reference', function(assert) {
       let decorate = decorator(desc => {
         delete desc.descriptor.value;
         delete desc.descriptor.writable;

--- a/packages/component/addon/index.js
+++ b/packages/component/addon/index.js
@@ -1,7 +1,10 @@
 import { assert } from '@ember/debug';
 
 import collapseProto from '@ember-decorators/utils/collapse-proto';
-import { decoratorWithParams, decoratorWithRequiredParams } from '@ember-decorators/utils/decorator';
+import {
+  decoratorWithParams,
+  decoratorWithRequiredParams,
+} from '@ember-decorators/utils/decorator';
 
 /**
   Decorator which indicates that the field or computed should be bound
@@ -38,28 +41,31 @@ export const attribute = decoratorWithParams((desc, params = []) => {
     params.every(s => typeof s === 'string')
   );
 
-  desc.finisher = target => {
-    let { prototype } = target;
-    let { key, descriptor } = desc;
+  return {
+    ...desc,
+    finisher(target) {
+      let { prototype } = target;
+      let { key, descriptor } = desc;
 
-    collapseProto(prototype);
+      collapseProto(prototype);
 
-    if (!prototype.hasOwnProperty('attributeBindings')) {
-      let parentValue = prototype.attributeBindings;
-      prototype.attributeBindings = Array.isArray(parentValue) ? parentValue.slice() : [];
-    }
+      if (!prototype.hasOwnProperty('attributeBindings')) {
+        let parentValue = prototype.attributeBindings;
+        prototype.attributeBindings = Array.isArray(parentValue) ? parentValue.slice() : [];
+      }
 
-    let binding = params[0] ? `${key}:${params[0]}` : key;
+      let binding = params[0] ? `${key}:${params[0]}` : key;
 
-    prototype.attributeBindings.push(binding);
+      prototype.attributeBindings.push(binding);
 
-    if (descriptor) {
-      // Decorated fields are currently not configurable in Babel for some reason, so ensure
-      // that the field becomes configurable (else it messes with things)
-      descriptor.configurable = true;
-    }
+      if (descriptor) {
+        // Decorated fields are currently not configurable in Babel for some reason, so ensure
+        // that the field becomes configurable (else it messes with things)
+        descriptor.configurable = true;
+      }
 
-    return target;
+      return target;
+    },
   };
 });
 
@@ -101,28 +107,31 @@ export const className = decoratorWithParams((desc, params = []) => {
     params.every(s => typeof s === 'string')
   );
 
-  desc.finisher = target => {
-    let { prototype } = target;
-    let { key, descriptor } = desc;
+  return {
+    ...desc,
+    finisher(target) {
+      let { prototype } = target;
+      let { key, descriptor } = desc;
 
-    collapseProto(prototype);
+      collapseProto(prototype);
 
-    if (!prototype.hasOwnProperty('classNameBindings')) {
-      let parentValue = prototype.classNameBindings;
-      prototype.classNameBindings = Array.isArray(parentValue) ? parentValue.slice() : [];
-    }
+      if (!prototype.hasOwnProperty('classNameBindings')) {
+        let parentValue = prototype.classNameBindings;
+        prototype.classNameBindings = Array.isArray(parentValue) ? parentValue.slice() : [];
+      }
 
-    let binding = params.length > 0 ? `${key}:${params.join(':')}` : key;
+      let binding = params.length > 0 ? `${key}:${params.join(':')}` : key;
 
-    prototype.classNameBindings.push(binding);
+      prototype.classNameBindings.push(binding);
 
-    if (descriptor) {
-      // Decorated fields are currently not configurable in Babel for some reason, so ensure
-      // that the field becomes configurable (else it messes with things)
-      descriptor.configurable = true;
-    }
+      if (descriptor) {
+        // Decorated fields are currently not configurable in Babel for some reason, so ensure
+        // that the field becomes configurable (else it messes with things)
+        descriptor.configurable = true;
+      }
 
-    return target;
+      return target;
+    },
   };
 });
 
@@ -144,19 +153,22 @@ export const classNames = decoratorWithRequiredParams((desc, classNames) => {
     classNames.reduce((allStrings, name) => allStrings && typeof name === 'string', true)
   );
 
-  desc.finisher = target => {
-    let { prototype } = target;
+  return {
+    ...desc,
+    finisher(target) {
+      let { prototype } = target;
 
-    collapseProto(prototype);
+      collapseProto(prototype);
 
-    if ('classNames' in prototype) {
-      let parentClasses = prototype.classNames;
-      classNames.unshift(...parentClasses);
-    }
+      if ('classNames' in prototype) {
+        let parentClasses = prototype.classNames;
+        classNames.unshift(...parentClasses);
+      }
 
-    prototype.classNames = classNames;
+      prototype.classNames = classNames;
 
-    return target;
+      return target;
+    },
   };
 }, 'classNames');
 
@@ -183,9 +195,12 @@ export const tagName = decoratorWithRequiredParams((desc, params) => {
     typeof tagName === 'string'
   );
 
-  desc.finisher = target => {
-    target.prototype.tagName = tagName;
-    return target;
+  return {
+    ...desc,
+    finisher(target) {
+      target.prototype.tagName = tagName;
+      return target;
+    },
   };
 }, 'tagName');
 
@@ -230,8 +245,11 @@ export const layout = decoratorWithRequiredParams((desc, params) => {
     (() => typeof template === 'object' && typeof template.indexOf === 'undefined')()
   );
 
-  desc.finisher = target => {
-    target.prototype.layout = template;
-    return target;
+  return {
+    ...desc,
+    finisher(target) {
+      target.prototype.layout = template;
+      return target;
+    },
   };
 }, 'layout');

--- a/packages/component/addon/index.js
+++ b/packages/component/addon/index.js
@@ -41,32 +41,31 @@ export const attribute = decoratorWithParams((desc, params = []) => {
     params.every(s => typeof s === 'string')
   );
 
-  return {
-    ...desc,
-    finisher(target) {
-      let { prototype } = target;
-      let { key, descriptor } = desc;
+  desc.finisher = target => {
+    let { prototype } = target;
+    let { key, descriptor } = desc;
 
-      collapseProto(prototype);
+    collapseProto(prototype);
 
-      if (!prototype.hasOwnProperty('attributeBindings')) {
-        let parentValue = prototype.attributeBindings;
-        prototype.attributeBindings = Array.isArray(parentValue) ? parentValue.slice() : [];
-      }
+    if (!prototype.hasOwnProperty('attributeBindings')) {
+      let parentValue = prototype.attributeBindings;
+      prototype.attributeBindings = Array.isArray(parentValue) ? parentValue.slice() : [];
+    }
 
-      let binding = params[0] ? `${key}:${params[0]}` : key;
+    let binding = params[0] ? `${key}:${params[0]}` : key;
 
-      prototype.attributeBindings.push(binding);
+    prototype.attributeBindings.push(binding);
 
-      if (descriptor) {
-        // Decorated fields are currently not configurable in Babel for some reason, so ensure
-        // that the field becomes configurable (else it messes with things)
-        descriptor.configurable = true;
-      }
+    if (descriptor) {
+      // Decorated fields are currently not configurable in Babel for some reason, so ensure
+      // that the field becomes configurable (else it messes with things)
+      descriptor.configurable = true;
+    }
 
-      return target;
-    },
+    return target;
   };
+
+  return desc;
 });
 
 /**
@@ -107,32 +106,31 @@ export const className = decoratorWithParams((desc, params = []) => {
     params.every(s => typeof s === 'string')
   );
 
-  return {
-    ...desc,
-    finisher(target) {
-      let { prototype } = target;
-      let { key, descriptor } = desc;
+  desc.finisher = target => {
+    let { prototype } = target;
+    let { key, descriptor } = desc;
 
-      collapseProto(prototype);
+    collapseProto(prototype);
 
-      if (!prototype.hasOwnProperty('classNameBindings')) {
-        let parentValue = prototype.classNameBindings;
-        prototype.classNameBindings = Array.isArray(parentValue) ? parentValue.slice() : [];
-      }
+    if (!prototype.hasOwnProperty('classNameBindings')) {
+      let parentValue = prototype.classNameBindings;
+      prototype.classNameBindings = Array.isArray(parentValue) ? parentValue.slice() : [];
+    }
 
-      let binding = params.length > 0 ? `${key}:${params.join(':')}` : key;
+    let binding = params.length > 0 ? `${key}:${params.join(':')}` : key;
 
-      prototype.classNameBindings.push(binding);
+    prototype.classNameBindings.push(binding);
 
-      if (descriptor) {
-        // Decorated fields are currently not configurable in Babel for some reason, so ensure
-        // that the field becomes configurable (else it messes with things)
-        descriptor.configurable = true;
-      }
+    if (descriptor) {
+      // Decorated fields are currently not configurable in Babel for some reason, so ensure
+      // that the field becomes configurable (else it messes with things)
+      descriptor.configurable = true;
+    }
 
-      return target;
-    },
+    return target;
   };
+
+  return desc;
 });
 
 /**
@@ -153,23 +151,22 @@ export const classNames = decoratorWithRequiredParams((desc, classNames) => {
     classNames.reduce((allStrings, name) => allStrings && typeof name === 'string', true)
   );
 
-  return {
-    ...desc,
-    finisher(target) {
-      let { prototype } = target;
+  desc.finisher = target => {
+    let { prototype } = target;
 
-      collapseProto(prototype);
+    collapseProto(prototype);
 
-      if ('classNames' in prototype) {
-        let parentClasses = prototype.classNames;
-        classNames.unshift(...parentClasses);
-      }
+    if ('classNames' in prototype) {
+      let parentClasses = prototype.classNames;
+      classNames.unshift(...parentClasses);
+    }
 
-      prototype.classNames = classNames;
+    prototype.classNames = classNames;
 
-      return target;
-    },
+    return target;
   };
+
+  return desc;
 }, 'classNames');
 
 /**
@@ -195,13 +192,12 @@ export const tagName = decoratorWithRequiredParams((desc, params) => {
     typeof tagName === 'string'
   );
 
-  return {
-    ...desc,
-    finisher(target) {
-      target.prototype.tagName = tagName;
-      return target;
-    },
+  desc.finisher = target => {
+    target.prototype.tagName = tagName;
+    return target;
   };
+
+  return desc;
 }, 'tagName');
 
 /**
@@ -245,11 +241,10 @@ export const layout = decoratorWithRequiredParams((desc, params) => {
     (() => typeof template === 'object' && typeof template.indexOf === 'undefined')()
   );
 
-  return {
-    ...desc,
-    finisher(target) {
-      target.prototype.layout = template;
-      return target;
-    },
+  desc.finisher = target => {
+    target.prototype.layout = template;
+    return target;
   };
+
+  return desc;
 }, 'layout');

--- a/packages/object/addon/index.js
+++ b/packages/object/addon/index.js
@@ -43,24 +43,23 @@ export const action = decorator(desc => {
     desc && desc.descriptor && typeof desc.descriptor.value === 'function'
   );
 
-  return {
-    ...desc,
-    finisher(target) {
-      let { key, descriptor } = desc;
-      let { prototype } = target;
+  desc.finisher = target => {
+    let { key, descriptor } = desc;
+    let { prototype } = target;
 
-      collapseProto(prototype);
+    collapseProto(prototype);
 
-      if (!prototype.hasOwnProperty('actions')) {
-        let parentActions = prototype.actions;
-        prototype.actions = parentActions ? Object.create(parentActions) : {};
-      }
+    if (!prototype.hasOwnProperty('actions')) {
+      let parentActions = prototype.actions;
+      prototype.actions = parentActions ? Object.create(parentActions) : {};
+    }
 
-      prototype.actions[key] = descriptor.value;
+    prototype.actions[key] = descriptor.value;
 
-      return target;
-    },
+    return target;
   };
+
+  return desc;
 });
 
 /**
@@ -159,18 +158,17 @@ export const observes = decoratorWithRequiredParams((desc, params) => {
     desc && desc.descriptor && typeof desc.descriptor.value === 'function'
   );
 
-  return {
-    ...desc,
-    finisher(target) {
-      let { prototype } = target;
+  desc.finisher = target => {
+    let { prototype } = target;
 
-      for (let path of params) {
-        addObserver(prototype, path, null, desc.key);
-      }
+    for (let path of params) {
+      addObserver(prototype, path, null, desc.key);
+    }
 
-      return target;
-    },
+    return target;
   };
+
+  return desc;
 }, 'observes');
 
 /**
@@ -194,21 +192,19 @@ export const observes = decoratorWithRequiredParams((desc, params) => {
   @function
   @param {...String} propertyNames - Names of the properties that no longer trigger the function
  */
-export const unobserves = decoratorWithRequiredParams(
-  (desc, params) => ({
-    ...desc,
-    finisher(target) {
-      let { prototype } = target;
+export const unobserves = decoratorWithRequiredParams((desc, params) => {
+  desc.finisher = target => {
+    let { prototype } = target;
 
-      for (let path of params) {
-        removeObserver(prototype, path, null, desc.key);
-      }
+    for (let path of params) {
+      removeObserver(prototype, path, null, desc.key);
+    }
 
-      return target;
-    },
-  }),
-  'unobserves'
-);
+    return target;
+  };
+
+  return desc;
+}, 'unobserves');
 
 /**
   Adds an event listener to the target function.
@@ -233,18 +229,17 @@ export const on = decoratorWithRequiredParams((desc, params) => {
     desc && desc.descriptor && typeof desc.descriptor.value === 'function'
   );
 
-  return {
-    ...desc,
-    finisher(target) {
-      let { prototype } = target;
+  desc.finisher = target => {
+    let { prototype } = target;
 
-      for (let eventName of params) {
-        addListener(prototype, eventName, null, desc.key);
-      }
+    for (let eventName of params) {
+      addListener(prototype, eventName, null, desc.key);
+    }
 
-      return target;
-    },
+    return target;
   };
+
+  return desc;
 }, 'on');
 
 /**
@@ -268,21 +263,19 @@ export const on = decoratorWithRequiredParams((desc, params) => {
   @function
   @param {...String} eventNames - Names of the events that no longer trigger the function
  */
-export const off = decoratorWithRequiredParams(
-  (desc, params) => ({
-    ...desc,
-    finisher(target) {
-      let { prototype } = target;
+export const off = decoratorWithRequiredParams((desc, params) => {
+  desc.finisher = target => {
+    let { prototype } = target;
 
-      for (let eventName of params) {
-        removeListener(prototype, eventName, null, desc.key);
-      }
+    for (let eventName of params) {
+      removeListener(prototype, eventName, null, desc.key);
+    }
 
-      return target;
-    },
-  }),
-  'off'
-);
+    return target;
+  };
+
+  return desc;
+}, 'off');
 
 /**
   Decorator that modifies a computed property to be read only.
@@ -302,9 +295,8 @@ export const off = decoratorWithRequiredParams(
 
   @return {ComputedProperty}
 */
-export const readOnly = decorator(desc => ({
-  ...desc,
-  finisher(target) {
+export const readOnly = decorator(desc => {
+  desc.finisher = target => {
     let { prototype } = target;
     let { key } = desc;
 
@@ -333,8 +325,10 @@ export const readOnly = decorator(desc => ({
       let modifierMeta = getOrCreateModifierMeta(prototype, name);
       modifierMeta[key] = 'readOnly';
     }
-  },
-}));
+  };
+
+  return desc;
+});
 
 /**
   Decorator that modifies a computed property to be volatile.
@@ -354,9 +348,8 @@ export const readOnly = decorator(desc => ({
 
   @return {ComputedProperty}
 */
-export const volatile = decorator(desc => ({
-  ...desc,
-  finisher(target) {
+export const volatile = decorator(desc => {
+  desc.finisher = target => {
     let { prototype } = target;
     let { key } = desc;
 
@@ -385,5 +378,7 @@ export const volatile = decorator(desc => ({
       let modifierMeta = getOrCreateModifierMeta(prototype, name);
       modifierMeta[key] = 'volatile';
     }
-  },
-}));
+  };
+
+  return desc;
+});

--- a/packages/object/addon/index.js
+++ b/packages/object/addon/index.js
@@ -43,20 +43,23 @@ export const action = decorator(desc => {
     desc && desc.descriptor && typeof desc.descriptor.value === 'function'
   );
 
-  desc.finisher = target => {
-    let { key, descriptor } = desc;
-    let { prototype } = target;
+  return {
+    ...desc,
+    finisher(target) {
+      let { key, descriptor } = desc;
+      let { prototype } = target;
 
-    collapseProto(prototype);
+      collapseProto(prototype);
 
-    if (!prototype.hasOwnProperty('actions')) {
-      let parentActions = prototype.actions;
-      prototype.actions = parentActions ? Object.create(parentActions) : {};
-    }
+      if (!prototype.hasOwnProperty('actions')) {
+        let parentActions = prototype.actions;
+        prototype.actions = parentActions ? Object.create(parentActions) : {};
+      }
 
-    prototype.actions[key] = descriptor.value;
+      prototype.actions[key] = descriptor.value;
 
-    return target;
+      return target;
+    },
   };
 });
 
@@ -156,14 +159,17 @@ export const observes = decoratorWithRequiredParams((desc, params) => {
     desc && desc.descriptor && typeof desc.descriptor.value === 'function'
   );
 
-  desc.finisher = target => {
-    let { prototype } = target;
+  return {
+    ...desc,
+    finisher(target) {
+      let { prototype } = target;
 
-    for (let path of params) {
-      addObserver(prototype, path, null, desc.key);
-    }
+      for (let path of params) {
+        addObserver(prototype, path, null, desc.key);
+      }
 
-    return target;
+      return target;
+    },
   };
 }, 'observes');
 
@@ -188,17 +194,21 @@ export const observes = decoratorWithRequiredParams((desc, params) => {
   @function
   @param {...String} propertyNames - Names of the properties that no longer trigger the function
  */
-export const unobserves = decoratorWithRequiredParams((desc, params) => {
-  desc.finisher = target => {
-    let { prototype } = target;
+export const unobserves = decoratorWithRequiredParams(
+  (desc, params) => ({
+    ...desc,
+    finisher(target) {
+      let { prototype } = target;
 
-    for (let path of params) {
-      removeObserver(prototype, path, null, desc.key);
-    }
+      for (let path of params) {
+        removeObserver(prototype, path, null, desc.key);
+      }
 
-    return target;
-  };
-}, 'unobserves');
+      return target;
+    },
+  }),
+  'unobserves'
+);
 
 /**
   Adds an event listener to the target function.
@@ -223,14 +233,17 @@ export const on = decoratorWithRequiredParams((desc, params) => {
     desc && desc.descriptor && typeof desc.descriptor.value === 'function'
   );
 
-  desc.finisher = target => {
-    let { prototype } = target;
+  return {
+    ...desc,
+    finisher(target) {
+      let { prototype } = target;
 
-    for (let eventName of params) {
-      addListener(prototype, eventName, null, desc.key);
-    }
+      for (let eventName of params) {
+        addListener(prototype, eventName, null, desc.key);
+      }
 
-    return target;
+      return target;
+    },
   };
 }, 'on');
 
@@ -255,17 +268,21 @@ export const on = decoratorWithRequiredParams((desc, params) => {
   @function
   @param {...String} eventNames - Names of the events that no longer trigger the function
  */
-export const off = decoratorWithRequiredParams((desc, params) => {
-  desc.finisher = target => {
-    let { prototype } = target;
+export const off = decoratorWithRequiredParams(
+  (desc, params) => ({
+    ...desc,
+    finisher(target) {
+      let { prototype } = target;
 
-    for (let eventName of params) {
-      removeListener(prototype, eventName, null, desc.key);
-    }
+      for (let eventName of params) {
+        removeListener(prototype, eventName, null, desc.key);
+      }
 
-    return target;
-  };
-}, 'off');
+      return target;
+    },
+  }),
+  'off'
+);
 
 /**
   Decorator that modifies a computed property to be read only.
@@ -285,8 +302,9 @@ export const off = decoratorWithRequiredParams((desc, params) => {
 
   @return {ComputedProperty}
 */
-export const readOnly = decorator(desc => {
-  desc.finisher = target => {
+export const readOnly = decorator(desc => ({
+  ...desc,
+  finisher(target) {
     let { prototype } = target;
     let { key } = desc;
 
@@ -315,8 +333,8 @@ export const readOnly = decorator(desc => {
       let modifierMeta = getOrCreateModifierMeta(prototype, name);
       modifierMeta[key] = 'readOnly';
     }
-  };
-});
+  },
+}));
 
 /**
   Decorator that modifies a computed property to be volatile.
@@ -336,8 +354,9 @@ export const readOnly = decorator(desc => {
 
   @return {ComputedProperty}
 */
-export const volatile = decorator(desc => {
-  desc.finisher = target => {
+export const volatile = decorator(desc => ({
+  ...desc,
+  finisher(target) {
     let { prototype } = target;
     let { key } = desc;
 
@@ -366,5 +385,5 @@ export const volatile = decorator(desc => {
       let modifierMeta = getOrCreateModifierMeta(prototype, name);
       modifierMeta[key] = 'volatile';
     }
-  };
-});
+  },
+}));

--- a/packages/utils/addon/computed.js
+++ b/packages/utils/addon/computed.js
@@ -63,6 +63,8 @@ function computedDecoratorInner(fn) {
 
       return target;
     }
+
+    return desc;
   }
 }
 

--- a/packages/utils/addon/decorator.js
+++ b/packages/utils/addon/decorator.js
@@ -79,30 +79,35 @@ function convertStage1ToStage2(desc) {
   }
 }
 
+function deprecateDirectDescriptorMutation(fn, desc) {
+  let returnValue = fn(desc);
+
+  if (!returnValue) {
+    deprecate(
+      `@ember-decorators/utils: Directly mutating the descriptor by reference is deprecated. Return it instead.`,
+      false,
+      {
+        id: 'ember-decorators.utils.decorator.descriptor-mutation-by-reference',
+        until: '4.0.0',
+      }
+    );
+    return desc;
+  }
+
+  return returnValue;
+}
+
 export function decorator(fn) {
   if (NEEDS_STAGE_1_DECORATORS) {
     return function(...params) {
       if (isStage2Descriptor(params)) {
         let desc = params[0];
 
-        return fn(desc);
+        return deprecateDirectDescriptorMutation(fn, desc);
       } else {
         let desc = convertStage1ToStage2(params);
 
-        let returnValue = fn(desc);
-
-        if (!returnValue) {
-          deprecate(
-            `@ember-decorators/utils: Directly mutating the descriptor by reference is deprecated. Return it instead.`,
-            false,
-            {
-              id: 'ember-decorators.utils.decorator.descriptor-mutation-by-reference',
-              until: '4.0.0',
-            }
-          );
-        } else {
-          desc = returnValue;
-        }
+        desc = deprecateDirectDescriptorMutation(fn, desc);
 
         if (typeof desc.finisher === 'function') {
           // Finishers are supposed to run at the end of class finalization,

--- a/packages/utils/addon/decorator.js
+++ b/packages/utils/addon/decorator.js
@@ -90,7 +90,7 @@ export function decorator(fn) {
       } else {
         let desc = convertStage1ToStage2(params);
 
-        fn(desc);
+        desc = fn(desc);
 
         if (typeof desc.finisher === 'function') {
           // Finishers are supposed to run at the end of class finalization,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,6 +1671,13 @@ babel-plugin-ember-modules-api-polyfill@^2.5.0:
   dependencies:
     ember-rfc176-data "^0.3.5"
 
+babel-plugin-ember-modules-api-polyfill@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.6.0.tgz#9524a65ef0c31ee82536a19c243fbaec1b977cbb"
+  integrity sha512-BSbLv3+ju1mcUUoPe7vPJgnGawrNxp6LfFBRHlNOKeMlQlml9Wo2MRRUrbpNDlmVc761xSKj8+cde7R0Lwpq7g==
+  dependencies:
+    ember-rfc176-data "^0.3.6"
+
 babel-plugin-feature-flags@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-feature-flags/-/babel-plugin-feature-flags-0.3.1.tgz#9c827cf9a4eb9a19f725ccb239e85cab02036fc1"
@@ -2458,7 +2465,7 @@ broccoli-file-creator@^2.1.1:
     broccoli-plugin "^1.1.0"
     mkdirp "^0.5.1"
 
-broccoli-filter@^1.2.2, broccoli-filter@^1.2.3, broccoli-filter@^1.2.4:
+broccoli-filter@^1.0.1, broccoli-filter@^1.2.2, broccoli-filter@^1.2.3, broccoli-filter@^1.2.4:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.3.0.tgz#71e3a8e32a17f309e12261919c5b1006d6766de6"
   integrity sha512-VXJXw7eBfG82CFxaBDjYmyN7V72D4In2zwLVQJd/h3mBfF3CMdRTsv2L20lmRTtCv1sAHcB+LgMso90e/KYiLw==
@@ -4512,6 +4519,25 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
+ember-cli-babel@^6.9.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
+  integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
+  dependencies:
+    amd-name-resolver "1.2.0"
+    babel-plugin-debug-macros "^0.2.0-beta.6"
+    babel-plugin-ember-modules-api-polyfill "^2.6.0"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.26.0"
+    babel-preset-env "^1.7.0"
+    broccoli-babel-transpiler "^6.5.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.1.2"
+    semver "^5.5.0"
+
 ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.1.3.tgz#a2a7374adb525369a3a205cedd54d8e0c3de3309"
@@ -5425,6 +5451,14 @@ ember-native-dom-helpers@^0.5.0, ember-native-dom-helpers@^0.5.10:
     broccoli-funnel "^1.1.0"
     ember-cli-babel "^6.6.0"
 
+ember-qunit-assert-helpers@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ember-qunit-assert-helpers/-/ember-qunit-assert-helpers-0.2.1.tgz#4a77f8ff252e47cc53db6fa7fb4becb426de8d29"
+  integrity sha512-3h7jdwp/Lzpri04hrSzUz0hguzzF7ldnCEb+tB+5MianGiFusYjPEu8QsUqJ6BhzXlljyX+pmMVyNe7HL6lsjA==
+  dependencies:
+    broccoli-filter "^1.0.1"
+    ember-cli-babel "^6.9.0"
+
 ember-qunit@^3.5.0:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-3.5.3.tgz#bfd0bff8298c78c77e870cca43fe0826e78a0d09"
@@ -5475,6 +5509,11 @@ ember-rfc176-data@^0.3.1, ember-rfc176-data@^0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.5.tgz#f630e550572c81a5e5c7220f864c0f06eee9e977"
   integrity sha512-5NfL1iTkIQDYs16/IZ7/jWCEglNsUrigLelBkBMsNcib9T3XzQwmhhVTjoSsk66s57LmWJ1bQu+2c1CAyYCV7A==
+
+ember-rfc176-data@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.6.tgz#7138db8dfccec39c9a832adfbd4c49d670028907"
+  integrity sha512-kPY94VCukPUPj+/6sZ9KvphD42KnpX2IS31p5z07OFVIviDogR0cQuld5c7Irzfgq7a0YACj0HlToROFn7dLYQ==
 
 ember-root-url@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
While writing tests for legacy decorators for https://github.com/rwjblue/sparkles-component/pull/22, I noticed that the return value is ignored and that the descriptor needs to be mutated by reference.

I don't think that this is intentional, since we do the opposite for stage 2 decorators using the same callback function.