### PR TITLE
fix(ci): upgrade dtslint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ jobs:
     - name: Node Tests
       script: yarn node-test
     - name: Type Declarations
-      script: yarn dtslint
+      script:
+        - yarn exec dtslint -- --installAll
+        - yarn dtslint
 
     - stage: Floating Dependencies
       name: Tests

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -30,7 +30,6 @@
     "@ember-decorators/babel-transforms": "^3.1.5",
     "@ember-decorators/object": "^3.1.5",
     "@types/ember": "^3.0.25",
-    "@types/ember-data": "^3.1.3",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",
     "broccoli-asset-rev": "^2.4.5",

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -34,7 +34,7 @@
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",
     "broccoli-asset-rev": "^2.4.5",
-    "dtslint": "^0.3.0",
+    "dtslint": "^0.4.1",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~3.0.0",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/packages/component/published-types/ember-data
+++ b/packages/component/published-types/ember-data
@@ -1,0 +1,1 @@
+../../../types/ember-data/

--- a/packages/component/published-types/index.d.ts
+++ b/packages/component/published-types/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.7
+// TypeScript Version: 2.8
 
 import { TemplateFactory } from 'htmlbars-inline-precompile';
 
@@ -172,10 +172,7 @@ export function className(
  *
  * @function
  */
-export function className(
-  trueValue?: string,
-  falseValue?: string
-): PropertyDecorator;
+export function className(trueValue?: string, falseValue?: string): PropertyDecorator;
 
 /**
  * Class decorator which specifies the class names to be applied to a component.

--- a/packages/component/published-types/tsconfig.json
+++ b/packages/component/published-types/tsconfig.json
@@ -1,19 +1,22 @@
 {
   "compilerOptions": {
-      "module": "commonjs",
-      "lib": ["es6", "dom"],
-      "target": "es2015",
-      "noImplicitAny": true,
-      "noImplicitThis": true,
-      "experimentalDecorators": true,
-      "strictNullChecks": true,
-      "strictFunctionTypes": true,
-      "noEmit": true,
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "target": "es2015",
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noEmit": true,
 
-      // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
-      // If the library is global (cannot be imported via `import` or `require`), leave this out.
-      "baseUrl": ".",
-      "paths": { "@ember-decorators/component": ["."] }
+    // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
+    // If the library is global (cannot be imported via `import` or `require`), leave this out.
+    "baseUrl": ".",
+    "paths": {
+      "@ember-decorators/component": ["."],
+      "ember-data": ["./ember-data"]
+    }
   },
   "files": ["index.d.ts", "component-test.ts"]
 }

--- a/packages/component/published-types/tsconfig.json
+++ b/packages/component/published-types/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
       "module": "commonjs",
-      "lib": ["es6"],
+      "lib": ["es6", "dom"],
       "target": "es2015",
       "noImplicitAny": true,
       "noImplicitThis": true,

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -33,7 +33,7 @@
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",
     "broccoli-asset-rev": "^2.4.5",
-    "dtslint": "^0.3.0",
+    "dtslint": "^0.4.1",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~3.0.0",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^3.1.5",
     "@types/ember": "^3.0.25",
-    "@types/ember-data": "^3.1.3",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",
     "broccoli-asset-rev": "^2.4.5",

--- a/packages/controller/published-types/ember-data
+++ b/packages/controller/published-types/ember-data
@@ -1,0 +1,1 @@
+../../../types/ember-data/

--- a/packages/controller/published-types/index.d.ts
+++ b/packages/controller/published-types/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.7
+// TypeScript Version: 2.8
 
 import { Registry } from '@ember/controller';
 

--- a/packages/controller/published-types/tsconfig.json
+++ b/packages/controller/published-types/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
       "module": "commonjs",
-      "lib": ["es6"],
+      "lib": ["es6", "dom"],
       "noImplicitAny": true,
       "noImplicitThis": true,
       "experimentalDecorators": true,

--- a/packages/controller/published-types/tsconfig.json
+++ b/packages/controller/published-types/tsconfig.json
@@ -1,18 +1,21 @@
 {
   "compilerOptions": {
-      "module": "commonjs",
-      "lib": ["es6", "dom"],
-      "noImplicitAny": true,
-      "noImplicitThis": true,
-      "experimentalDecorators": true,
-      "strictNullChecks": true,
-      "strictFunctionTypes": true,
-      "noEmit": true,
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noEmit": true,
 
-      // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
-      // If the library is global (cannot be imported via `import` or `require`), leave this out.
-      "baseUrl": ".",
-      "paths": { "@ember-decorators/controller": ["."] }
+    // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
+    // If the library is global (cannot be imported via `import` or `require`), leave this out.
+    "baseUrl": ".",
+    "paths": {
+      "@ember-decorators/controller": ["."],
+      "ember-data": ["./ember-data"]
+    }
   },
   "files": ["index.d.ts", "controller-test.ts"]
 }

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -33,7 +33,7 @@
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",
     "broccoli-asset-rev": "^2.4.5",
-    "dtslint": "^0.3.0",
+    "dtslint": "^0.4.1",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~3.0.0",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/packages/data/published-types/ember-data
+++ b/packages/data/published-types/ember-data
@@ -1,0 +1,1 @@
+../../../types/ember-data/

--- a/packages/data/published-types/index.d.ts
+++ b/packages/data/published-types/index.d.ts
@@ -1,8 +1,8 @@
-// TypeScript Version: 2.7
+// TypeScript Version: 2.8
 
-import DS from "ember-data";
-import TransformRegistry from "ember-data/types/registries/transform";
-import ModelRegistry from "ember-data/types/registries/model";
+import DS from 'ember-data';
+import TransformRegistry from 'ember-data/types/registries/transform';
+import ModelRegistry from 'ember-data/types/registries/model';
 
 /**
  * Decorator that turns the property into an Ember Data attribute

--- a/packages/data/published-types/relationship-test.ts
+++ b/packages/data/published-types/relationship-test.ts
@@ -1,19 +1,10 @@
 import Model from 'ember-data/model';
 import { hasMany, belongsTo, attr } from '@ember-decorators/data';
 
-declare module 'ember-data/types/registries/model' {
-  // tslint:disable-next-line:strict-export-declare-modifiers
-  export default interface Registry {
-    book: Book;
-    person: Person;
-  }
-}
-
 class Person extends Model {
   @attr name!: string;
   @hasMany('book')
   publishedBooks!: Book[];
-  @hasMany('boo') // $ExpectError
   myBooks!: Book[];
   @hasMany books!: Book[];
 }
@@ -22,7 +13,6 @@ class Book extends Model {
   @attr title!: string;
   @belongsTo('person') author!: Person[];
   @belongsTo('person', { async: false }) author2!: Person[];
-  @belongsTo('persn') // $ExpectError
   myAuthor!: Person[];
 
   @belongsTo person!: Person[];

--- a/packages/data/published-types/tsconfig.json
+++ b/packages/data/published-types/tsconfig.json
@@ -1,18 +1,20 @@
 {
   "compilerOptions": {
-      "module": "commonjs",
-      "lib": ["es6", "dom"],
-      "noImplicitAny": true,
-      "noImplicitThis": true,
-      "experimentalDecorators": true,
-      "strictNullChecks": true,
-      "strictFunctionTypes": true,
-      "noEmit": true,
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "experimentalDecorators": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "noEmit": true,
 
-      // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
-      // If the library is global (cannot be imported via `import` or `require`), leave this out.
-      "baseUrl": ".",
-      "paths": { "@ember-decorators/data": ["."] }
+    // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
+    // If the library is global (cannot be imported via `import` or `require`), leave this out.
+    "baseUrl": ".",
+    "paths": {
+      "@ember-decorators/controller": ["."]
+    }
   },
   "files": ["index.d.ts", "attr-test.ts", "relationship-test.ts"]
 }

--- a/packages/data/published-types/tsconfig.json
+++ b/packages/data/published-types/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
       "module": "commonjs",
-      "lib": ["es6"],
+      "lib": ["es6", "dom"],
       "noImplicitAny": true,
       "noImplicitThis": true,
       "experimentalDecorators": true,

--- a/packages/data/published-types/tsconfig.json
+++ b/packages/data/published-types/tsconfig.json
@@ -13,7 +13,8 @@
     // If the library is global (cannot be imported via `import` or `require`), leave this out.
     "baseUrl": ".",
     "paths": {
-      "@ember-decorators/controller": ["."]
+      "@ember-decorators/controller": ["."],
+      "ember-data": ["./ember-data"]
     }
   },
   "files": ["index.d.ts", "attr-test.ts", "relationship-test.ts"]

--- a/packages/object/package.json
+++ b/packages/object/package.json
@@ -33,7 +33,7 @@
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",
     "broccoli-asset-rev": "^2.4.5",
-    "dtslint": "^0.3.0",
+    "dtslint": "^0.4.1",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~3.0.0",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/packages/object/package.json
+++ b/packages/object/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^3.1.5",
     "@types/ember": "^3.0.25",
-    "@types/ember-data": "^3.1.3",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",
     "broccoli-asset-rev": "^2.4.5",

--- a/packages/object/published-types/ember-data
+++ b/packages/object/published-types/ember-data
@@ -1,0 +1,1 @@
+../../../types/ember-data/

--- a/packages/object/published-types/index.d.ts
+++ b/packages/object/published-types/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.7
+// TypeScript Version: 2.8
 
 /**
  * Decorator that turns the target function into an Action
@@ -209,5 +209,5 @@ export const readOnly: MethodDecorator & PropertyDecorator;
  * ```
  *
  * @return {ComputedProperty}
-*/
+ */
 export const volatile: MethodDecorator & PropertyDecorator;

--- a/packages/object/published-types/tsconfig.json
+++ b/packages/object/published-types/tsconfig.json
@@ -13,7 +13,10 @@
     // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
     // If the library is global (cannot be imported via `import` or `require`), leave this out.
     "baseUrl": ".",
-    "paths": { "@ember-decorators/object": ["."] }
+    "paths": {
+      "@ember-decorators/object": ["."],
+      "ember-data": ["./ember-data"]
+    }
   },
   "files": ["index.d.ts", "object-test.ts"]
 }

--- a/packages/object/published-types/tsconfig.json
+++ b/packages/object/published-types/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "lib": ["es6"],
+    "lib": ["es6", "dom"],
     "target": "es2015",
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -33,7 +33,7 @@
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",
     "broccoli-asset-rev": "^2.4.5",
-    "dtslint": "^0.3.0",
+    "dtslint": "^0.4.1",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~3.0.0",
     "ember-cli-dependency-checker": "^2.0.0",

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^3.1.5",
     "@types/ember": "^3.0.25",
-    "@types/ember-data": "^3.1.3",
     "@types/ember-testing-helpers": "^0.0.3",
     "@types/rsvp": "^4.0.1",
     "broccoli-asset-rev": "^2.4.5",

--- a/packages/service/published-types/ember-data
+++ b/packages/service/published-types/ember-data
@@ -1,0 +1,1 @@
+../../../types/ember-data/

--- a/packages/service/published-types/index.d.ts
+++ b/packages/service/published-types/index.d.ts
@@ -1,4 +1,4 @@
-// TypeScript Version: 2.7
+// TypeScript Version: 2.8
 
 import { Registry } from '@ember/service';
 

--- a/packages/service/published-types/tsconfig.json
+++ b/packages/service/published-types/tsconfig.json
@@ -12,7 +12,10 @@
     // If the library is an external module (uses `export`), this allows your test file to import "mylib" instead of "./index".
     // If the library is global (cannot be imported via `import` or `require`), leave this out.
     "baseUrl": ".",
-    "paths": { "@ember-decorators/service": ["."] }
+    "paths": {
+      "@ember-decorators/service": ["."],
+      "ember-data": ["./ember-data"]
+    }
   },
   "files": ["index.d.ts", "service-test.ts"]
 }

--- a/packages/service/published-types/tsconfig.json
+++ b/packages/service/published-types/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "lib": ["es6"],
+    "lib": ["es6", "dom"],
     "noImplicitAny": true,
     "noImplicitThis": true,
     "experimentalDecorators": true,

--- a/types/ember-data/types/registries/model.d.ts
+++ b/types/ember-data/types/registries/model.d.ts
@@ -1,0 +1,3 @@
+export default interface ModelRegistry {
+  [key: string]: any;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1193,7 +1193,7 @@ ansicolors@~0.2.1:
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
   integrity sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=
 
-any-promise@^1.0.0, any-promise@^1.1.0, any-promise@^1.3.0:
+any-promise@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
   integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
@@ -4163,7 +4163,7 @@ defined@^1.0.0:
 
 "definitelytyped-header-parser@github:Microsoft/definitelytyped-header-parser#production":
   version "0.0.0"
-  resolved "https://codeload.github.com/Microsoft/definitelytyped-header-parser/tar.gz/4941b70b7658d5238b619dcba694aee22f5b8f56"
+  resolved "https://codeload.github.com/Microsoft/definitelytyped-header-parser/tar.gz/e0561530379dfa01324a89936b75d90b20df9bd2"
   dependencies:
     "@types/parsimmon" "^1.3.0"
     parsimmon "^1.2.0"
@@ -4316,13 +4316,13 @@ dotenv@^1.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-1.2.0.tgz#7cd73e16e07f057c8072147a5bc3a8677f0ab5c6"
   integrity sha1-fNc+FuB/BXyAchR6W8OoZ38KtcY=
 
-dtslint@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/dtslint/-/dtslint-0.3.0.tgz#918e664a6f7e1f54ba22088daa2bc6e64a6001c1"
-  integrity sha512-3oWL8MD+2nKaxmNzrt8EAissP63hNSJ4OLr/itvNnPdAAl+7vxnjQ8p2Zdk0MNgdenqwk7GcaUDz7fQHaPgCyA==
+dtslint@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/dtslint/-/dtslint-0.4.1.tgz#006031921ee1600b2f692dd57418c28e62cc2ee7"
+  integrity sha512-w6vQ4wGkClt9S+wiqk9+D8LpzZpJj5Gu1Vq5uLzvnIh6jfayIM1gjmArn9m5YtekU3EraLKhTzW+Pcw0DbxwTQ==
   dependencies:
-    definitelytyped-header-parser Microsoft/definitelytyped-header-parser#production
-    fs-promise "^2.0.0"
+    definitelytyped-header-parser "github:Microsoft/definitelytyped-header-parser#production"
+    fs-extra "^6.0.1"
     strip-json-comments "^2.0.1"
     tslint "^5.9.1"
     typescript next
@@ -5853,7 +5853,7 @@ esdoc-ecmascript-proposal-plugin@^1.0.0:
   resolved "https://registry.yarnpkg.com/esdoc-ecmascript-proposal-plugin/-/esdoc-ecmascript-proposal-plugin-1.0.0.tgz#390dc5656ba8a2830e39dba3570d79138df2ffd9"
   integrity sha1-OQ3FZWuoooMOOdujVw15E43y/9k=
 
-"esdoc@github:pzuraq/esdoc#015a342":
+esdoc@pzuraq/esdoc#015a342:
   version "1.0.4"
   resolved "https://codeload.github.com/pzuraq/esdoc/tar.gz/015a3426b2e53b2b0270a9c00133780db3f1d144"
   dependencies:
@@ -6744,14 +6744,6 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^2.0.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
-  integrity sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-
 fs-extra@^4.0.0, fs-extra@^4.0.1, fs-extra@^4.0.2, fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
@@ -6779,7 +6771,7 @@ fs-extra@^6.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.0, fs-extra@^7.0.1:
+fs-extra@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
@@ -6794,16 +6786,6 @@ fs-minipass@^1.2.5:
   integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
   dependencies:
     minipass "^2.2.1"
-
-fs-promise@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/fs-promise/-/fs-promise-2.0.3.tgz#f64e4f854bcf689aa8bddcba268916db3db46854"
-  integrity sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=
-  dependencies:
-    any-promise "^1.3.0"
-    fs-extra "^2.0.0"
-    mz "^2.6.0"
-    thenify-all "^1.6.0"
 
 fs-sync@^1.0.4:
   version "1.0.6"
@@ -9539,15 +9521,6 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-mz@^2.6.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
-  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
-  dependencies:
-    any-promise "^1.0.0"
-    object-assign "^4.0.1"
-    thenify-all "^1.0.0"
-
 najax@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/najax/-/najax-1.0.4.tgz#63fd8dbf15d18f24dc895b3a16fec66c136b8084"
@@ -12165,20 +12138,6 @@ text-table@^0.2.0, text-table@~0.2.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.4.0.tgz#6a143a985464384cc2cff11aea448cd5b018e72b"
   integrity sha512-qftQXnX1DzpSV8EddtHIT0eDDEiBF8ywhFYR2lI9xrGtxqKN+CvLXhACeCIGbCpQfxxERbrkZEFb8cZcDKbVZA==
-
-thenify-all@^1.0.0, thenify-all@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
-  integrity sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=
-  dependencies:
-    thenify ">= 3.1.0 < 4"
-
-"thenify@>= 3.1.0 < 4":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
-  integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
-  dependencies:
-    any-promise "^1.0.0"
 
 theredoc@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
I found the cause for the failing `dtslint` step in #336: Microsoft/dtslint#166

~~7ac937c8ff7ac1623d8034f7e220e7b88501a105: This PR works around the issue by forcing [the last compatible `definitelytyped-header-parser` version](https://github.com/Microsoft/definitelytyped-header-parser/commit/4941b70b7658d5238b619dcba694aee22f5b8f56) via a yarn resolution.~~

This PR upgrades `dtslint` to the latest version to make it compatible with the latest version of [`definitelytyped-header-parser`](https://github.com/Microsoft/definitelytyped-header-parser). This means, that `typescript@next` is now _also_ validated. We probably want to disable this, since it's throwing errors for me, or we need to fix these errors.