### PR TITLE
fix(package): move published-types to pkg root before publishing

### DIFF
--- a/packages/component/.npmignore
+++ b/packages/component/.npmignore
@@ -18,3 +18,6 @@ testem.js
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+
+# The `index.d.ts` is moved one level up by the `prepack` script
+/published-types

--- a/packages/component/package.json
+++ b/packages/component/package.json
@@ -20,7 +20,9 @@
     "build": "ember build",
     "start": "echo \"Run serve in the main ember-decorators package\" && false",
     "test": "echo \"Run tests in the main ember-decorators package\" && false",
-    "dtslint": "dtslint published-types"
+    "dtslint": "dtslint published-types",
+    "prepack": "mv ./published-types/index.d.ts ./",
+    "postpack": "mv ./index.d.ts ./published-types/"
   },
   "dependencies": {
     "@ember-decorators/utils": "^3.1.5",

--- a/packages/controller/.npmignore
+++ b/packages/controller/.npmignore
@@ -18,3 +18,6 @@ testem.js
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+
+# The `index.d.ts` is moved one level up by the `prepack` script
+/published-types

--- a/packages/controller/package.json
+++ b/packages/controller/package.json
@@ -20,7 +20,9 @@
     "build": "ember build",
     "start": "echo \"Run serve in the main ember-decorators package\" && false",
     "test": "echo \"Run tests in the main ember-decorators package\" && false",
-    "dtslint": "dtslint published-types"
+    "dtslint": "dtslint published-types",
+    "prepack": "mv ./published-types/index.d.ts ./",
+    "postpack": "mv ./index.d.ts ./published-types/"
   },
   "dependencies": {
     "@ember-decorators/utils": "^3.1.5",

--- a/packages/data/.npmignore
+++ b/packages/data/.npmignore
@@ -18,3 +18,6 @@ testem.js
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+
+# The `index.d.ts` is moved one level up by the `prepack` script
+/published-types

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -20,7 +20,9 @@
     "build": "ember build",
     "start": "echo \"Run serve in the main ember-decorators package\" && false",
     "test": "echo \"Run tests in the main ember-decorators package\" && false",
-    "dtslint": "dtslint published-types"
+    "dtslint": "dtslint published-types",
+    "prepack": "mv ./published-types/index.d.ts ./",
+    "postpack": "mv ./index.d.ts ./published-types/"
   },
   "dependencies": {
     "@ember-decorators/utils": "^3.1.5",

--- a/packages/object/.npmignore
+++ b/packages/object/.npmignore
@@ -18,3 +18,6 @@ testem.js
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+
+# The `index.d.ts` is moved one level up by the `prepack` script
+/published-types

--- a/packages/object/package.json
+++ b/packages/object/package.json
@@ -20,7 +20,9 @@
     "build": "ember build",
     "start": "echo \"Run serve in the main ember-decorators package\" && false",
     "test": "echo \"Run tests in the main ember-decorators package\" && false",
-    "dtslint": "dtslint published-types"
+    "dtslint": "dtslint published-types",
+    "prepack": "mv ./published-types/index.d.ts ./",
+    "postpack": "mv ./index.d.ts ./published-types/"
   },
   "dependencies": {
     "@ember-decorators/utils": "^3.1.5",

--- a/packages/service/.npmignore
+++ b/packages/service/.npmignore
@@ -18,3 +18,6 @@ testem.js
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+
+# The `index.d.ts` is moved one level up by the `prepack` script
+/published-types

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -20,7 +20,9 @@
     "build": "ember build",
     "start": "echo \"Run serve in the main ember-decorators package\" && false",
     "test": "echo \"Run tests in the main ember-decorators package\" && false",
-    "dtslint": "dtslint published-types"
+    "dtslint": "dtslint published-types",
+    "prepack": "mv ./published-types/index.d.ts ./",
+    "postpack": "mv ./index.d.ts ./published-types/"
   },
   "dependencies": {
     "@ember-decorators/utils": "^3.1.5",


### PR DESCRIPTION
Fixes #342.

This PR moves the `published-types/index.d.ts` one level up in the `prepack` script and undoes this in the `postpack` script.

> - `prepack`: run BEFORE a tarball is packed (on `npm pack`, `npm publish`, and when installing git dependencies)
> - `postpack`: Run AFTER the tarball has been generated and moved to its final destination.

— [npm docs](https://docs.npmjs.com/misc/scripts#description)

It also add the `published-types` directory to `.npmignore`, since it now does not contain anything useful to the package consumer any more (AFAICT).