### PR TITLE
[FEAT] Adds wrapComputed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,5 +67,4 @@ jobs:
     - env: EMBER_TRY_SCENARIO=production
     - env: EMBER_TRY_SCENARIO=stage-1-transforms
     - env: EMBER_TRY_SCENARIO=forced-stage-1-build
-    - env: EMBER_TRY_SCENARIO=throw-on-computed-override
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -100,12 +100,6 @@ module.exports = function() {
             EMBER_DECORATORS_NEEDS_STAGE_1_DECORATORS: true,
           },
         },
-        {
-          name: 'throw-on-computed-override',
-          env: {
-            EMBER_DECORATORS_THROW_ON_COMPUTED_OVERRIDE: true,
-          },
-        },
       ],
     };
   });

--- a/packages/-ember-decorators/tests/unit/object/computed-test.js
+++ b/packages/-ember-decorators/tests/unit/object/computed-test.js
@@ -284,6 +284,7 @@ module('@computed', function() {
     new Bar();
     new Baz();
   });
+
   if (DEBUG) {
     test('throws if used on non-getters', function(assert) {
       assert.throws(
@@ -379,44 +380,46 @@ module('@computed', function() {
       get(obj, 'fullName');
     });
 
-    test('it throws if it recieves more than one argument', function(assert) {
-      assert.throws(
-        () => {
-          class Foo {
-            @wrapComputed(emberComputed(function() {}), 'bar') name;
-          }
+    if (DEBUG) {
+      test('it throws if it recieves more than one argument', function(assert) {
+        assert.throws(
+          () => {
+            class Foo {
+              @wrapComputed(emberComputed(function() {}), 'bar') name;
+            }
 
-          new Foo();
-        },
-        /wrapComputed should receive exactly one parameter, a ComputedProperty/
-      );
-    })
+            new Foo();
+          },
+          /wrapComputed should receive exactly one parameter, a ComputedProperty/
+        );
+      })
 
-    test('it throws if it receives non-CP', function(assert) {
-      assert.throws(
-        () => {
-          class Foo {
-            @wrapComputed('foo') name;
-          }
+      test('it throws if it receives non-CP', function(assert) {
+        assert.throws(
+          () => {
+            class Foo {
+              @wrapComputed('foo') name;
+            }
 
-          new Foo();
-        },
-        /wrapComputed should receive an instance of a ComputedProperty. Received foo for name/
-      );
-    });
+            new Foo();
+          },
+          /wrapComputed should receive an instance of a ComputedProperty. Received foo for name/
+        );
+      });
 
-    test('it throws if it receives a ComputedDecorator', function(assert) {
-      assert.throws(
-        () => {
-          class Foo {
-            @wrapComputed(computed('foo', 'bar')) name;
-          }
+      test('it throws if it receives a ComputedDecorator', function(assert) {
+        assert.throws(
+          () => {
+            class Foo {
+              @wrapComputed(computed('foo', 'bar')) name;
+            }
 
-          new Foo();
-        },
-        /wrapComputed received a ComputedDecorator for name. Because the value is already a decorator, there is no need to wrap it./
-      );
-    });
+            new Foo();
+          },
+          /wrapComputed received a ComputedDecorator for name. Because the value is already a decorator, there is no need to wrap it./
+        );
+      });
+    }
   });
 
   module('modifiers', function() {

--- a/packages/object/addon/index.js
+++ b/packages/object/addon/index.js
@@ -1,6 +1,7 @@
 import { assert } from '@ember/debug';
 
 import { computed as emberComputed } from '@ember/object';
+import ComputedProperty from '@ember/object/computed';
 import { addListener, removeListener } from '@ember/object/events';
 import { addObserver, removeObserver } from '@ember/object/observers';
 
@@ -152,7 +153,8 @@ export const action = decorator(desc => {
 
   @function
   @param {...string} propertyNames - List of property keys this computed is dependent on
-  @return {ComputedProperty}
+  @param {ComputedPropertyDesc?} desc - Optional computed property getter/setter
+  @return {ComputedDecorator}
 */
 export const computed = computedDecoratorWithParams(({ key, descriptor, initializer }, params = []) => {
   assert(
@@ -167,6 +169,12 @@ export const computed = computedDecoratorWithParams(({ key, descriptor, initiali
 
   let lastArg = params[params.length - 1];
   let get, set;
+
+  assert(
+    `computed properties should not be passed to @computed directly, use wrapComputed for the value passed to ${key} instead`,
+    !((typeof lastArg === 'function' || typeof lastArg === 'object') && lastArg.isDescriptor)
+  );
+
 
   if (typeof lastArg === 'function') {
     params.pop();
@@ -218,6 +226,37 @@ export const computed = computedDecoratorWithParams(({ key, descriptor, initiali
   }
 
   return emberComputed(...params, { get, set: setter });
+});
+
+/**
+  Wraps an instance of a ComputedProperty, turning it into a decorator:
+
+  ```js
+  import Component from '@ember/component';
+  import { computed } from '@ember/object';
+  import { wrapComputed } from '@ember-decorators/object';
+
+  export default class UserProfileComponent extends Component {
+    first = 'Bruce';
+    last = 'Wayne';
+
+    @wrapComputed(
+      computed('first', 'last', function() {
+        return `${this.first} ${this.last}`; // => 'Bruce Wayne'
+      })
+    ) fullName;
+  }
+  ```
+
+  @param {ComputedProperty} cp - an instance of a computed property
+  @return {ComputedDecorator}
+*/
+export const wrapComputed = computedDecoratorWithParams((desc, params) => {
+  assert(`wrapComputed should receive exactly one parameter, a ComputedProperty. Received ${params} for ${desc.key}`, params.length === 1);
+  assert(`wrapComputed should receive an instance of a ComputedProperty. Received ${params} for ${desc.key}`, params[0] instanceof ComputedProperty);
+  assert(`wrapComputed received a ComputedDecorator for ${desc.key}. Because the value is already a decorator, there is no need to wrap it.`, !params[0].__isComputedDecorator);
+
+  return params[0];
 });
 
 /**

--- a/packages/object/addon/index.js
+++ b/packages/object/addon/index.js
@@ -172,7 +172,7 @@ export const computed = computedDecoratorWithParams(({ key, descriptor, initiali
 
   assert(
     `computed properties should not be passed to @computed directly, use wrapComputed for the value passed to ${key} instead`,
-    !((typeof lastArg === 'function' || typeof lastArg === 'object') && lastArg.isDescriptor)
+    !((typeof lastArg === 'function' || typeof lastArg === 'object') && lastArg instanceof ComputedProperty)
   );
 
 

--- a/packages/object/published-types/index.d.ts
+++ b/packages/object/published-types/index.d.ts
@@ -167,6 +167,31 @@ export const computed: {
 } & PropertyDecorator;
 
 /**
+  Wraps an instance of a ComputedProperty, turning it into a decorator:
+
+  ```js
+  import Component from '@ember/component';
+  import { computed } from '@ember/object';
+  import { wrapComputed } from '@ember-decorators/object';
+
+  export default class UserProfileComponent extends Component {
+    first = 'Bruce';
+    last = 'Wayne';
+
+    @wrapComputed(
+      computed('first', 'last', function() {
+        return `${this.first} ${this.last}`; // => 'Bruce Wayne'
+      })
+    ) fullName;
+  }
+  ```
+
+  @param {ComputedProperty} cp - an instance of a computed property
+  @return {ComputedDecorator}
+*/
+export function wrapComputed<T>(cp: ComputedProperty<T>): ComputedDecorator<T>;
+
+/**
   Triggers the target function when the dependent properties have changed
 
   ```javascript

--- a/packages/object/published-types/object-test.ts
+++ b/packages/object/published-types/object-test.ts
@@ -1,6 +1,7 @@
-import EmberObject from '@ember/object';
-import { computed, observes, unobserves, on, off, action } from '@ember-decorators/object';
+import EmberObject, { computed as emberComputed } from '@ember/object';
+import { computed, observes, unobserves, on, off, action, wrapComputed } from '@ember-decorators/object';
 import { alias } from '@ember-decorators/object/computed';
+import { test } from 'qunit';
 
 export default class UserProfileComponent extends EmberObject {
   first = 'John';
@@ -27,6 +28,8 @@ export default class UserProfileComponent extends EmberObject {
     const [first, last] = value.split(' ');
     this.setProperties({ first, last });
   }
+
+  @wrapComputed(emberComputed(() => {})) test: any;
 }
 
 export class Foo {

--- a/packages/object/published-types/object-test.ts
+++ b/packages/object/published-types/object-test.ts
@@ -29,7 +29,9 @@ export default class UserProfileComponent extends EmberObject {
     this.setProperties({ first, last });
   }
 
-  @wrapComputed(emberComputed(() => {})) test: any;
+  @wrapComputed(emberComputed(() => {
+    return 'foo';
+  })) fooString: string;
 }
 
 export class Foo {
@@ -76,5 +78,20 @@ export const Baz = EmberObject.extend({
     return `${first} ${last}`; // => 'John Smith'
   }),
 
-  nameAlias: alias('name')
+  nameAlias: alias('name'),
+
+  fooString: wrapComputed(
+    emberComputed({
+      get() {
+        return 'foo';
+      },
+      set(key, value: string) {
+        return value;
+      }
+    })
+  )
 });
+
+// Make sure wrapComputed doesn't interfere with typings
+const baz = Baz.create();
+const obj: { foo: string } = { foo: baz.get('fooString') };

--- a/packages/utils/addon/-private/class-field-descriptor.js
+++ b/packages/utils/addon/-private/class-field-descriptor.js
@@ -20,7 +20,7 @@ if (NEEDS_STAGE_1_DECORATORS) {
     } else if (possibleDesc.length === 1) {
       let [target] = possibleDesc;
 
-      return typeof target === 'function' && 'prototype' in target;
+      return typeof target === 'function' && 'prototype' in target && !target.__isComputedDecorator;
     }
 
     return false;

--- a/packages/utils/addon/computed.js
+++ b/packages/utils/addon/computed.js
@@ -6,6 +6,7 @@ import { decorator } from './decorator';
 import { computedDescriptorFor, isComputedDescriptor } from './-private/descriptor';
 import { isFieldDescriptor } from './-private/class-field-descriptor';
 
+import { DEBUG } from '@glimmer/env';
 import { assert } from '@ember/debug';
 import ComputedProperty from '@ember/object/computed';
 
@@ -150,6 +151,11 @@ export function computedDecorator(fn, params) {
   });
 
   Object.setPrototypeOf(dec, DecoratorDescriptor.prototype);
+
+  if (DEBUG) {
+    // This is for wrapComputed to check against invalid input
+    dec.__isComputedDecorator = true;
+  }
 
   DECORATOR_COMPUTED_FN.set(dec, fn);
   DECORATOR_PARAMS.set(dec, params);


### PR DESCRIPTION
Adds a function that allows users to wrap existing computed properties, filling in the gaps left by `macro`. This is a temporary method that will become a noop in apps that support decorators.