### PR TITLE
[BUGFIX] Fixes observers

### DIFF
--- a/packages/-ember-decorators/tests/unit/object/computed-test.js
+++ b/packages/-ember-decorators/tests/unit/object/computed-test.js
@@ -425,7 +425,7 @@ module('@computed', function() {
   module('modifiers', function() {
     test('volatile', function(assert) {
       assert.expect(2);
-      class Foo {
+      class Foo extends EmberObject {
         _count = 0;
 
         @(computed('first').volatile())

--- a/packages/-ember-decorators/tests/unit/object/unobserves-test.js
+++ b/packages/-ember-decorators/tests/unit/object/unobserves-test.js
@@ -1,14 +1,17 @@
 import { DEBUG } from '@glimmer/env';
+import { NEEDS_STAGE_1_DECORATORS } from 'ember-decorators-flags';
 
 import { module, test } from 'ember-qunit';
-import { set } from '@ember/object';
+import EmberObject, { set } from '@ember/object';
 
 import { observes, unobserves } from '@ember-decorators/object';
 
 module('@unobserves', function() {
 
   test('changing the key does not calls the method', function(assert) {
-    class Foo {
+    assert.expect(0);
+
+    class Foo extends EmberObject {
       @observes('first', 'last')
       fullName() {
         assert.ok(false, 'observer method has been called');
@@ -22,14 +25,12 @@ module('@unobserves', function() {
     let obj = new Bar();
     set(obj, 'first', 'yehuda');
     set(obj, 'last', 'katz');
-
-    assert.ok(true, 'observer method has not been called');
   });
 
   test('it is possible to override the method', function(assert) {
     assert.expect(1);
 
-    class Foo {
+    class Foo extends EmberObject {
       @observes('first', 'last')
       fullName() {
         assert.ok(false, 'old method has been called');
@@ -47,11 +48,59 @@ module('@unobserves', function() {
     obj.fullName();
   });
 
+  test('it works with expanded/chained properties on EmberObject based classes', function(assert) {
+    assert.expect(0);
+
+    class Foo extends EmberObject {
+      init() {
+        super.init(...arguments);
+
+        this.person = {};
+      }
+
+      @observes('person.{first,last}')
+      fullName() {
+        assert.ok(false, 'observer method has been called');
+      }
+    }
+
+    class Bar extends Foo {
+      @unobserves('person.{first,last}') fullName;
+    }
+
+    let obj = new Bar();
+    set(obj, 'person.first', 'yehuda');
+    set(obj.person, 'last', 'katz');
+  });
+
+  if (!NEEDS_STAGE_1_DECORATORS) {
+    test('it works with expanded/chained properties on plain classes', function(assert) {
+      assert.expect(0);
+
+      class Foo {
+        person = {};
+
+        @observes('person.{first,last}')
+        fullName() {
+          assert.ok(false, 'observer method has been called');
+        }
+      }
+
+      class Bar extends Foo {
+        @unobserves('person.{first,last}') fullName;
+      }
+
+      let obj = new Bar();
+      set(obj, 'person.first', 'yehuda');
+      set(obj.person, 'last', 'katz');
+    });
+  }
+
   if (DEBUG) {
     test('throws if decorator params are not provided', function(assert) {
       assert.throws(
         () => {
-          class Foo {
+          class Foo extends EmberObject {
             first = 'rob';
             last = 'jackson';
 


### PR DESCRIPTION
Fixes two major problems with observers:

1. They didn't expand properties
2. They would completely break if used with non EmberObject based
   classes.

This PR fixes both issues, but only for stage 2 transforms. It works by
adding another field to the class that is a dummy field and finishes
chains during initialization.

This is very very hacky, but it should be possible to do this much
better with `kind = 'initializer'` descriptors in stage 3, once they're
implemented. It shouldn't mess with shape or anything (I don't think),
will just be a bit ugly. The prop is non-enumerable too, so should be
very little impact.