### PR TITLE
Fix documentation of @observes

### DIFF
--- a/packages/object/addon/index.js
+++ b/packages/object/addon/index.js
@@ -261,6 +261,9 @@ export const wrapComputed = computedDecoratorWithParams((desc, params) => {
   return params[0];
 });
 
+let hasChainsFinished = false;
+const CHAINS_FINISHED = new WeakMap();
+
 /**
   Triggers the target function when the dependent properties have changed
 
@@ -278,9 +281,6 @@ export const wrapComputed = computedDecoratorWithParams((desc, params) => {
   @function
   @param {...String} propertyNames - Names of the properties that trigger the function
  */
-let hasChainsFinished = false;
-const CHAINS_FINISHED = new WeakMap();
-
 export const observes = decoratorWithRequiredParams((desc, params) => {
   assert(
     'The @observes decorator must be applied to functions',

--- a/packages/object/addon/index.js
+++ b/packages/object/addon/index.js
@@ -250,6 +250,7 @@ export const computed = computedDecoratorWithParams(({ key, descriptor, initiali
   }
   ```
 
+  @function
   @param {ComputedProperty} cp - an instance of a computed property
   @return {ComputedDecorator}
 */


### PR DESCRIPTION
The documentation was not displaying on the documentation because the
the doc string was attached to the `hasChainsFinished` variable.

This commit fixes the issue by putting the documentation of @observes
close to the function.

## Before

![screenshot_2019-02-06 ember decorators](https://user-images.githubusercontent.com/13909/52329897-36396180-29f4-11e9-9083-92c304b3aab4.png)

![screenshot_2019-02-06 ember decorators 1](https://user-images.githubusercontent.com/13909/52329900-389bbb80-29f4-11e9-9adf-329e2751f205.png)

## After

![screenshot_2019-02-06 ember decorators 2](https://user-images.githubusercontent.com/13909/52329912-405b6000-29f4-11e9-814d-de6ac535d3f1.png)

![screenshot_2019-02-06 ember decorators 3](https://user-images.githubusercontent.com/13909/52329918-46514100-29f4-11e9-91a7-8993024f399b.png)

