### PR TITLE
Fix typo

### DIFF
--- a/packages/-ember-decorators/tests/dummy/app/pods/index/template.hbs
+++ b/packages/-ember-decorators/tests/dummy/app/pods/index/template.hbs
@@ -1,7 +1,7 @@
 {{docs-hero
   logo='ember'
   slimHeading='decorators'
-  byline='The Javascript of the Future, Today!'}}
+  byline='The JavaScript of the Future, Today!'}}
 
 <div class="docs-container docs-md">
   <section class="max-w-md mx-auto pb-8">


### PR DESCRIPTION
Fixes a typo. `Javascript` => `JavaScript`