### PR TITLE
[BUGFIX] Fix descriptor check for TypeScript v1 decorators

### DIFF
--- a/packages/object/addon/-private/util.js
+++ b/packages/object/addon/-private/util.js
@@ -19,7 +19,11 @@ export function legacyMacro(fn) {
 function getMethod(fn, elementDesc, params, required) {
   let method;
 
-  if (elementDesc !== undefined && typeof elementDesc.descriptor.value === 'function') {
+  if (
+    elementDesc !== undefined &&
+    elementDesc.descriptor !== undefined &&
+    typeof elementDesc.descriptor.value === 'function'
+  ) {
     deprecate(
       `Ember Decorators currently supports using the ${
         fn.name


### PR DESCRIPTION
This fixes a bug where the descriptor for a class field is undefined in apps that use `ember-cli-typescript@v1`. Fixes #407 