### PR TITLE
fix(deprecation): prefer _setClassicDecorator over _setComputedDecorator

### DIFF
--- a/packages/object/addon/-private/util.js
+++ b/packages/object/addon/-private/util.js
@@ -66,7 +66,8 @@ export function legacyMacroWithMethod(fn, required) {
         computed(elementDesc);
       };
 
-      Ember._setComputedDecorator(decorator);
+      let setClassicDecorator = Ember._setClassicDecorator || Ember._setComputedDecorator;
+      setClassicDecorator(decorator);
 
       if (DEBUG) {
         // This is for wrapComputed to check against invalid input

--- a/packages/utils/addon/computed.js
+++ b/packages/utils/addon/computed.js
@@ -76,7 +76,8 @@ if (gte('3.10.0')) {
     decorator.__computed = computed;
     Object.setPrototypeOf(decorator, ComputedDecoratorImpl.prototype);
 
-    Ember._setComputedDecorator(decorator);
+    let setClassicDecorator = Ember._setClassicDecorator || Ember._setComputedDecorator;
+    setClassicDecorator(decorator);
 
     if (DEBUG) {
       // This is for wrapComputed to check against invalid input


### PR DESCRIPTION
This fixes the deprecation added in Ember by PR https://github.com/emberjs/ember.js/pull/17833.

cc/ @pzuraq @rwjblue 