### PR TITLE
[FEATURE] Adds the @classNameBindings and @attributeBindings decorators

### DIFF
--- a/packages/-ember-decorators/tests/unit/component/attribute-bindings-test.js
+++ b/packages/-ember-decorators/tests/unit/component/attribute-bindings-test.js
@@ -1,0 +1,81 @@
+import Component from '@ember/component';
+import { attributeBindings } from '@ember-decorators/component';
+import { computed } from '@ember/object';
+
+import hbs from 'htmlbars-inline-precompile';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { find, findAll } from 'ember-native-dom-helpers';
+
+module('@attributeBindings', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('decorator adds attributes to component', async function(assert) {
+    @attributeBindings('role', 'foo:data-foo', 'id')
+    class FooComponent extends Component {
+      role = 'button';
+      foo = 'lol';
+
+      @computed
+      get id() {
+        return 'bar';
+      }
+    }
+
+    this.owner.register('component:foo-component', FooComponent);
+    this.owner.register('template:components/foo-component', hbs`Hello, world!`);
+
+    await render(hbs`{{foo-component}}`);
+
+    assert.ok(find('[role="button"]'));
+    assert.ok(find('[data-foo="lol"]'));
+    assert.ok(find('#bar'));
+  });
+
+  test('decorator does not add attribute to superclass', async function(assert) {
+    @attributeBindings('role')
+    class FooComponent extends Component {
+      role = 'button';
+    }
+
+    @attributeBindings('id')
+    class BarComponent extends FooComponent {
+      id = 'bar';
+    }
+
+    this.owner.register('component:foo-component', FooComponent);
+    this.owner.register('template:components/foo-component', hbs`Hello, world!`);
+
+    this.owner.register('component:bar-component', BarComponent);
+    this.owner.register('template:components/bar-component', hbs`Hello, moon!`);
+
+    await render(hbs`{{foo-component}}{{bar-component}}`);
+
+    assert.equal(findAll('[role="button"]').length, 2);
+    assert.equal(findAll('#bar').length, 1);
+  });
+
+  test('decorator works correctly through traditional and ES6 hierarchy', async function(assert) {
+    const FooComponent = Component.extend({
+      attributeBindings: ['role'],
+      role: 'button',
+    });
+
+    @attributeBindings('id')
+    class BarComponent extends FooComponent {
+      id = 'bar';
+    }
+
+    this.owner.register('component:foo-component', FooComponent);
+    this.owner.register('template:components/foo-component', hbs`Hello, world!`);
+
+    this.owner.register('component:bar-component', BarComponent);
+    this.owner.register('template:components/bar-component', hbs`Hello, moon!`);
+
+    await render(hbs`{{foo-component}}{{bar-component}}`);
+
+    assert.equal(findAll('[role="button"]').length, 2);
+    assert.equal(findAll('#bar').length, 1);
+  });
+});

--- a/packages/-ember-decorators/tests/unit/component/class-name-bindings-test.js
+++ b/packages/-ember-decorators/tests/unit/component/class-name-bindings-test.js
@@ -1,0 +1,120 @@
+import { DEBUG } from '@glimmer/env';
+
+import Component from '@ember/component';
+import { classNameBindings } from '@ember-decorators/component';
+import { computed } from '@ember/object';
+
+import hbs from 'htmlbars-inline-precompile';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { find, findAll } from 'ember-native-dom-helpers';
+
+module('@classNameBindings', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('decorator adds class to component', async function(assert) {
+    @classNameBindings('foo', 'bar')
+    class FooComponent extends Component {
+      foo = 'foo';
+
+      @computed
+      get bar() {
+        return 'bar';
+      }
+    }
+
+    this.owner.register('component:foo-component', FooComponent);
+    this.owner.register('template:components/foo-component', hbs`Hello, world!`);
+
+    await render(hbs`{{foo-component}}`);
+
+    assert.ok(find('.foo'));
+    assert.ok(find('.bar'));
+  });
+
+  test('decorator applies true/false class names', async function(assert) {
+    @classNameBindings('foo:is-foo', 'bar::is-not-bar', 'active::inactive', 'baz:is-baz')
+    class FooComponent extends Component {
+      foo = true;
+      bar = false;
+      active = true;
+      baz = false;
+    }
+
+    this.owner.register('component:foo-component', FooComponent);
+    this.owner.register('template:components/foo-component', hbs`Hello, world!`);
+
+    await render(hbs`{{foo-component}}`);
+
+    assert.ok(find('.is-foo'));
+    assert.ok(find('.is-not-bar'));
+    assert.notOk(find('.inactive'));
+    assert.notOk(find('.is-baz'));
+  });
+
+  if (DEBUG) {
+    test('decorator throws on incorrect parameter usage', function(assert) {
+      assert.throws(() => {
+        @classNameBindings('foo', 123)
+        class Foo extends Object {
+          foo = true;
+        }
+
+        Foo.create();
+      }, /The @classNameBindings decorator must be provided strings/);
+    });
+  }
+
+  test('decorator does not add class to superclass', async function(assert) {
+    @classNameBindings('foo')
+    class FooComponent extends Component {
+      foo = 'foo';
+    }
+
+    @classNameBindings('bar')
+    class BarComponent extends FooComponent {
+      @computed
+      get bar() {
+        return 'bar';
+      }
+    }
+
+    this.owner.register('component:foo-component', FooComponent);
+    this.owner.register('template:components/foo-component', hbs`Hello, world!`);
+
+    this.owner.register('component:bar-component', BarComponent);
+    this.owner.register('template:components/bar-component', hbs`Hello, moon!`);
+
+    await render(hbs`{{foo-component}}{{bar-component}}`);
+
+    assert.equal(findAll('.foo').length, 2);
+    assert.equal(findAll('.bar').length, 1);
+  });
+
+  test('decorator works correctly through traditional and ES6 hierarchy', async function(assert) {
+    const FooComponent = Component.extend({
+      classNameBindings: ['foo'],
+      foo: 'foo',
+    });
+
+    @classNameBindings('bar')
+    class BarComponent extends FooComponent {
+      @computed
+      get bar() {
+        return 'bar';
+      }
+    }
+
+    this.owner.register('component:foo-component', FooComponent);
+    this.owner.register('template:components/foo-component', hbs`Hello, world!`);
+
+    this.owner.register('component:bar-component', BarComponent);
+    this.owner.register('template:components/bar-component', hbs`Hello, moon!`);
+
+    await render(hbs`{{foo-component}}{{bar-component}}`);
+
+    assert.equal(findAll('.foo').length, 2);
+    assert.equal(findAll('.bar').length, 1);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6742,10 +6742,10 @@ ember-compatibility-helpers@^1.2.0:
     ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
-ember-component-css@^0.6.7:
-  version "0.6.9"
-  resolved "https://registry.yarnpkg.com/ember-component-css/-/ember-component-css-0.6.9.tgz#592983f5678e4abc2c0dc01a377f812506ddac5a"
-  integrity sha512-bQoEdks22RTBehDjmqvZSuOQQvT59uEN2Zse9hsruO7lgoVtd/dk1YuJd2B0mXZyR+6TEN7/R8yeLtTubsubMQ==
+ember-component-css@^0.6.7, ember-component-css@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/ember-component-css/-/ember-component-css-0.7.4.tgz#b8e94b062468721df6c9ea0c8739226c96809c9f"
+  integrity sha512-dJV6WyvIc4NZ2fSNhMWe4UJaSPLBtjQ4zHJ9bOg6UCMLHfTlwjJsn+rYqddMn65xau7MS8mwxa+otujQij0xEw==
   dependencies:
     broccoli-concat "^3.7.3"
     broccoli-funnel "^2.0.1"
@@ -6791,7 +6791,7 @@ ember-copy@^1.0.0:
   dependencies:
     ember-cli-babel "^6.6.0"
 
-"ember-data@2.x - 3.x", ember-data@^3.1.1:
+"ember-data@2.x - 3.x", ember-data@^3.1.1, ember-data@~3.10.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.10.0.tgz#b5f53a445ba1ee37890ec672b3dc3f869d8b3992"
   integrity sha512-QqKJ5/Co2wGBnD5FSUiO1tbhsjjiRS5uJUwD2vRa0suwNv5E9f+5S6Yww6O0B2z5nDRzRheBFZ7iRjbshQhWDg==
@@ -14892,7 +14892,7 @@ topo@2.x.x:
   dependencies:
     hoek "4.x.x"
 
-tough-cookie@>=0.12.0, tough-cookie@>=2.3.3, tough-cookie@^2.2.0, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
+tough-cookie@>=0.12.0, tough-cookie@>=2.3.3, tough-cookie@^2.2.0, tough-cookie@^2.3.4, tough-cookie@~2.4.0, tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
   integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==


### PR DESCRIPTION
Adds decorators for classNameBindings and attributeBindings directly. This
makes it easier to have a 1-1 conversion from classic classes to native
classes with classic components.

Fixes #450 