### PR TITLE
Add support for specifying sync/async for @observes.

### DIFF
--- a/packages/object/package.json
+++ b/packages/object/package.json
@@ -25,7 +25,8 @@
   },
   "dependencies": {
     "@ember-decorators/utils": "^6.1.1",
-    "ember-cli-babel": "^7.1.3"
+    "ember-cli-babel": "^7.1.3",
+    "ember-compatibility-helpers": "^1.1.2"
   },
   "devDependencies": {
     "@ember-decorators/babel-transforms": "^5.2.0",

--- a/packages/object/published-types/index.d.ts
+++ b/packages/object/published-types/index.d.ts
@@ -1,5 +1,10 @@
 // TypeScript Version: 2.8
 
+interface ObserverDefinition {
+  dependentKeys: string[];
+  sync: boolean;
+}
+
 /**
   Triggers the target function when the dependent properties have changed
 
@@ -18,6 +23,31 @@
   @param {...String} propertyNames - Names of the properties that trigger the function
  */
 export function observes(...propertyNames: string[]): MethodDecorator;
+
+/**
+  Triggers the target function when the dependent properties have changed
+
+  ```javascript
+  import EmberObject from '@ember/object';
+  import { observes } from '@ember-decorators/object';
+
+  class Foo extends EmberObject {
+    @observes({
+      dependentKeys: ['foo'],
+      sync: false,
+    })
+    bar() {
+      //...
+    }
+  }
+  ```
+
+  @function
+  @param {Object} definition - ObserverDefinition
+  @param {Array<String>} [definition.dependentKeys] - Names of the properties that trigger the function
+  @param {boolean} [definition.sync] - Whether the observer should fire synchronously or asynchronously
+ */
+export function observes(definition: ObserverDefinition): MethodDecorator;
 
 /**
   Removes observers from the target function.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7212,7 +7212,7 @@ esdoc-ecmascript-proposal-plugin@^1.0.0:
   resolved "https://registry.yarnpkg.com/esdoc-ecmascript-proposal-plugin/-/esdoc-ecmascript-proposal-plugin-1.0.0.tgz#390dc5656ba8a2830e39dba3570d79138df2ffd9"
   integrity sha1-OQ3FZWuoooMOOdujVw15E43y/9k=
 
-"esdoc@github:pzuraq/esdoc#015a342":
+esdoc@pzuraq/esdoc#015a342:
   version "1.0.4"
   resolved "https://codeload.github.com/pzuraq/esdoc/tar.gz/015a3426b2e53b2b0270a9c00133780db3f1d144"
   dependencies:


### PR DESCRIPTION
Ember 3.13 added support for specifying if an observer should be fired synchronously or asynchronously. Future versions of Ember will default to firing these observers asynchronously, but you can manually specify if you would like sync or async behaviors.

```javascript
import EmberObject from '@ember/object';
import { observes } from '@ember-decorators/object';

class Foo extends EmberObject {
  @observes({
    dependentKeys: ['foo'],
    sync: false, // run asynchronously regardless of the application wide default
  })
  bar() {
    //...
  }
}
```